### PR TITLE
pr-0.0.1-pub-qos0-no-msg-id

### DIFF
--- a/lib/hulaaki/decoder.ex
+++ b/lib/hulaaki/decoder.ex
@@ -99,6 +99,14 @@ defmodule Hulaaki.Decoder do
     {topic, rest} = extract_topic(message_bytes)
     <<id::size(16), message::binary>> = rest
 
+    # no message id if qos = 0
+    if qos == 0 do
+      id = 1 # arbitrary > 0 but needed to satisfy Message.publish below
+      message = rest
+    else
+      <<id::size(16), message::binary>> = rest
+    end
+    
     message = Message.publish(id, topic, message, dup, qos, retain)
     %{message: message, remainder: remainder}
   end

--- a/test/hulaaki/client_test.exs
+++ b/test/hulaaki/client_test.exs
@@ -2,6 +2,10 @@ defmodule Hulaaki.ClientTest do
   use ExUnit.Case
   alias Hulaaki.Message
 
+  # configure the mqtt server
+  @mqtt_host "192.168.16.62"
+  @mqtt_port 1883
+  
   defmodule SampleClient do
     use Hulaaki.Client
 
@@ -72,7 +76,7 @@ defmodule Hulaaki.ClientTest do
   end
 
   defp pre_connect(pid) do
-    options = [client_id: "some-name", host: "localhost", port: 1883]
+    options = [client_id: "some-name", host: @mqtt_host, port: @mqtt_port]
     pid |> SampleClient.connect options
   end
 
@@ -228,7 +232,7 @@ defmodule Hulaaki.ClientTest do
     spawn fn ->
       {:ok, pid2} = SampleClient.start_link(%{parent: self})
 
-      options = [client_id: "another-name", host: 'localhost', port: 1883]
+      options = [client_id: "another-name", host: @mqtt_host, port: @mqtt_port]
       pid2 |> SampleClient.connect options
 
       options = [id: 11_175, topic: "awesome", message: "a message",

--- a/test/hulaaki/connection_test.exs
+++ b/test/hulaaki/connection_test.exs
@@ -3,6 +3,10 @@ defmodule Hulaaki.ConnectionTest do
   alias Hulaaki.Connection
   alias Hulaaki.Message
 
+  # configure the mqtt server
+  @mqtt_host "192.168.16.62"
+  @mqtt_port 1883
+  
   # How to test disconnect message
 
   defp client_name do
@@ -24,7 +28,7 @@ defmodule Hulaaki.ConnectionTest do
 
   defp pre_connect(pid) do
     message = Message.connect(client_name, "", "", "", "", 0, 0, 0, 100)
-    Connection.connect(pid, message, [host: 'localhost', port: 1883])
+    Connection.connect(pid, message, [host: @mqtt_host, port: @mqtt_port])
   end
 
   defp post_disconnect(pid) do

--- a/test/hulaaki/encoder_test.exs
+++ b/test/hulaaki/encoder_test.exs
@@ -47,7 +47,33 @@ defmodule Hulaaki.EncoderTest do
     assert expected == received
   end
 
-  test "encodes fixed header for Publish struct" do
+  test "encodes fixed header for Publish struct qos 0" do
+    dup = 0
+    qos = 0
+    retain = 1
+    message = %Message.Publish{id: 203, topic: "test",
+                               message: "test", dup: dup,
+                               qos: qos, retain: retain}
+    received = Encoder.encode_fixed_header(message)
+    expected = <<3::size(4), dup::size(1), qos::size(2), retain::size(1)>> <> <<10>>
+
+    assert expected == received
+  end
+    
+  test "encodes fixed header for Publish struct qos 1" do
+    dup = 0
+    qos = 1
+    retain = 1
+    message = %Message.Publish{id: 203, topic: "test",
+                               message: "test", dup: dup,
+                               qos: qos, retain: retain}
+    received = Encoder.encode_fixed_header(message)
+    expected = <<3::size(4), dup::size(1), qos::size(2), retain::size(1)>> <> <<12>>
+
+    assert expected == received
+  end
+    
+  test "encodes fixed header for Publish struct qos 2" do
     dup = 0
     qos = 2
     retain = 1
@@ -324,7 +350,39 @@ defmodule Hulaaki.EncoderTest do
     assert expected == received
   end
 
-  test "encodes variable header for Publish struct" do
+  test "encodes variable header for Publish struct qos 0" do
+    id = :random.uniform(65_536)
+    topic = "topic"
+    message = "message"
+    dup = 0
+    qos = 0
+    retain = 1
+    message = %Message.Publish{id: id, topic: topic,
+                               message: message, dup: dup,
+                               qos: qos, retain: retain}
+    received = Encoder.encode_variable_header(message)
+    expected = <<byte_size(topic)::size(16)>> <> topic
+
+    assert expected == received
+  end
+
+  test "encodes variable header for Publish struct qos 1" do
+    id = :random.uniform(65_536)
+    topic = "topic"
+    message = "message"
+    dup = 0
+    qos = 1
+    retain = 1
+    message = %Message.Publish{id: id, topic: topic,
+                               message: message, dup: dup,
+                               qos: qos, retain: retain}
+    received = Encoder.encode_variable_header(message)
+    expected = <<byte_size(topic)::size(16)>> <> topic <> <<id::size(16)>>
+
+    assert expected == received
+  end
+  
+  test "encodes variable header for Publish struct qos 2" do
     id = :random.uniform(65_536)
     topic = "topic"
     message = "message"


### PR DESCRIPTION
Hi Suvash,

This is the pull request for the fix to not include (PUBLISH) or expect (SUBSCRIBE) a message id in a publish packets when qos == 0

Some tests added to test the difference between qos == 0 and qos != 0

Let me know if any problems.