### PR TITLE
Increase connection timeout

### DIFF
--- a/lib/hulaaki/connection.ex
+++ b/lib/hulaaki/connection.ex
@@ -136,7 +136,7 @@ defmodule Hulaaki.Connection do
   end
 
   defp open_tcp_socket(opts) do
-    timeout  = 100
+    timeout  = 1000
     host     = opts |> Keyword.fetch! :host
     host     = if is_binary(host), do: String.to_char_list(host), else: host
     port     = opts |> Keyword.fetch! :port


### PR DESCRIPTION
I suggest increase the timeout to 1000ms to avoid connection problems. When are connecting to other regions is common timeout exceed 100ms.