### PR TITLE
Implement client ping to server based on keepalive and callback on ping response timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. This change
 - Added link to CHANGELOG in the README
 - Add instructions on using Makefile for running tests.
 - Handle `gen_tcp` connection failures instead of crashing
+- Add automatic ping to server (based on keep alive) and expect ping response with callbacks
 
 ### Fixed
 - Replaces all occurences of 65_536 to 65_535 (max limit for 2 bytes)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.3.4
+FROM elixir:1.5.1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ defmodule SampleClient do
     IO.inspect options
   end
 
-  def on_pong(options) do
+  def on_ping_response(options) do
     IO.inspect options
   end
 end
@@ -74,7 +74,7 @@ Please refer to the inline documentation and tests to explore the
 documentation for now. This shall be improved over time.
 
 ## Immediate TODOs
-* Pingpong based heartbeat in Client based on the timeout.
+* Ping and Ping Response based heartbeat in Client based on the keep alive timeout.
 * .....
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -73,10 +73,6 @@ and test strategy.
 Please refer to the inline documentation and tests to explore the
 documentation for now. This shall be improved over time.
 
-## Immediate TODOs
-* Ping and Ping Response based heartbeat in Client based on the keep alive timeout.
-* .....
-
 ## Contributing
 
 Pull requests with appropriate tests and improvements are welcome.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ iex -S mix
 
 > {:ok, pid} = SampleClient.start_link(%{})
 
-> options = [client_id: "some-name", host: "localhost", port: 1883]
+> options = [client_id: "some-name-7490", host: "localhost", port: 1883]
 
 > SampleClient.connect(pid, options)
 

--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -45,10 +45,10 @@ defmodule Hulaaki.Client do
       ## GenServer callbacks
 
       def init(%{} = state) do
-        state = 
+        state =
           state
           |> Map.put(:keep_alive_interval, nil)
-          |> Map.put(:keep_alive_ref, nil)
+          |> Map.put(:keep_alive_timer_ref, nil)
         {:ok, state}
       end
 
@@ -242,17 +242,17 @@ defmodule Hulaaki.Client do
       def handle_info({:keep_alive}, state) do
         :ok = state.connection |> Connection.ping
         {:noreply, state}
-      end 
+      end
 
       ## Private functions
-      defp update_keep_alive_timer(%{keep_alive_interval: keep_alive_interval, keep_alive_ref: keep_alive_ref} = state) do 
-        if keep_alive_ref do 
-          Process.cancel_timer(keep_alive_ref)
+      defp update_keep_alive_timer(%{keep_alive_interval: keep_alive_interval, keep_alive_timer_ref: keep_alive_timer_ref} = state) do
+        if keep_alive_timer_ref do
+          Process.cancel_timer(keep_alive_timer_ref)
         end
 
-        keep_alive_ref = Process.send_after(self, {:keep_alive}, keep_alive_interval)
-        %{state | keep_alive_ref: keep_alive_ref}
-      end       
+        keep_alive_timer_ref = Process.send_after(self, {:keep_alive}, keep_alive_interval)
+        %{state | keep_alive_timer_ref: keep_alive_timer_ref}
+      end
 
       ## Overrideable callbacks
 
@@ -280,7 +280,7 @@ defmodule Hulaaki.Client do
                       on_subscribe: 1, on_subscribe_ack: 1,
                       on_unsubscribe: 1, on_unsubscribe_ack: 1,
                       on_subscribed_publish: 1, on_subscribed_publish_ack: 1,
-                      on_ping: 1,    on_pong: 1,
+                      on_ping: 1, on_pong: 1,
                       on_disconnect: 1]
     end
   end

--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -229,7 +229,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:received, %Message.PingResp{} = message}, state) do
-        on_pong [message: message, state: state]
+        on_ping_response [message: message, state: state]
         {:noreply, state}
       end
 
@@ -270,7 +270,7 @@ defmodule Hulaaki.Client do
       def on_subscribed_publish([message: message, state: state]), do: true
       def on_subscribed_publish_ack([message: message, state: state]), do: true
       def on_ping([message: message, state: state]), do: true
-      def on_pong([message: message, state: state]), do: true
+      def on_ping_response([message: message, state: state]), do: true
       def on_disconnect([message: message, state: state]), do: true
 
       defoverridable [on_connect: 1, on_connect_ack: 1,
@@ -280,7 +280,7 @@ defmodule Hulaaki.Client do
                       on_subscribe: 1, on_subscribe_ack: 1,
                       on_unsubscribe: 1, on_unsubscribe_ack: 1,
                       on_subscribed_publish: 1, on_subscribed_publish_ack: 1,
-                      on_ping: 1, on_pong: 1,
+                      on_ping: 1, on_ping_response: 1,
                       on_disconnect: 1]
     end
   end

--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -45,6 +45,10 @@ defmodule Hulaaki.Client do
       ## GenServer callbacks
 
       def init(%{} = state) do
+        state = 
+          state
+          |> Map.put(:keep_alive_interval, nil)
+          |> Map.put(:keep_alive_ref, nil)
         {:ok, state}
       end
 
@@ -77,7 +81,7 @@ defmodule Hulaaki.Client do
 
         connect_opts = [host: host, port: port, timeout: timeout]
         case state.connection |> Connection.connect(message, connect_opts) do
-          :ok -> {:reply, :ok, state}
+          :ok -> {:reply, :ok, %{state | keep_alive_interval: keep_alive * 1000}}
           {:error, reason} -> {:reply, {:error, reason}, state}
         end
       end
@@ -134,16 +138,19 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.Connect{} = message}, state) do
+        state = update_keep_alive_timer(state)
         on_connect [message: message, state: state]
         {:noreply, state}
       end
 
       def handle_info({:received, %Message.ConnAck{} = message}, state) do
+        state = update_keep_alive_timer(state)
         on_connect_ack [message: message, state: state]
         {:noreply, state}
       end
 
       def handle_info({:sent, %Message.Publish{} = message}, state) do
+        state = update_keep_alive_timer(state)
         on_publish [message: message, state: state]
         {:noreply, state}
       end
@@ -163,6 +170,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.PubAck{} = message}, state) do
+        state = update_keep_alive_timer(state)
         on_subscribed_publish_ack [message: message, state: state]
         {:noreply, state}
       end
@@ -177,6 +185,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.PubRel{} = message}, state) do
+        state = update_keep_alive_timer(state)
         on_publish_release [message: message, state: state]
         {:noreply, state}
       end
@@ -192,6 +201,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.Subscribe{} = message}, state) do
+        state = update_keep_alive_timer(state)
         on_subscribe [message: message, state: state]
         {:noreply, state}
       end
@@ -202,6 +212,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.Unsubscribe{} = message}, state) do
+        state = update_keep_alive_timer(state)
         on_unsubscribe [message: message, state: state]
         {:noreply, state}
       end
@@ -212,6 +223,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.PingReq{} = message}, state) do
+        state = update_keep_alive_timer(state)
         on_ping [message: message, state: state]
         {:noreply, state}
       end
@@ -222,9 +234,25 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.Disconnect{} = message}, state) do
+        state = update_keep_alive_timer(state)
         on_disconnect [message: message, state: state]
         {:noreply, state}
       end
+
+      def handle_info({:keep_alive}, state) do
+        :ok = state.connection |> Connection.ping
+        {:noreply, state}
+      end 
+
+      ## Private functions
+      defp update_keep_alive_timer(%{keep_alive_interval: keep_alive_interval, keep_alive_ref: keep_alive_ref} = state) do 
+        if keep_alive_ref do 
+          Process.cancel_timer(keep_alive_ref)
+        end
+
+        keep_alive_ref = Process.send_after(self, {:keep_alive}, keep_alive_interval)
+        %{state | keep_alive_ref: keep_alive_ref}
+      end       
 
       ## Overrideable callbacks
 

--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -138,19 +138,18 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.Connect{} = message}, state) do
-        state = update_keep_alive_timer(state)
+        state = reset_keep_alive_timer(state)
         on_connect [message: message, state: state]
         {:noreply, state}
       end
 
       def handle_info({:received, %Message.ConnAck{} = message}, state) do
-        state = update_keep_alive_timer(state)
         on_connect_ack [message: message, state: state]
         {:noreply, state}
       end
 
       def handle_info({:sent, %Message.Publish{} = message}, state) do
-        state = update_keep_alive_timer(state)
+        state = reset_keep_alive_timer(state)
         on_publish [message: message, state: state]
         {:noreply, state}
       end
@@ -170,7 +169,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.PubAck{} = message}, state) do
-        state = update_keep_alive_timer(state)
+        state = reset_keep_alive_timer(state)
         on_subscribed_publish_ack [message: message, state: state]
         {:noreply, state}
       end
@@ -185,7 +184,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.PubRel{} = message}, state) do
-        state = update_keep_alive_timer(state)
+        state = reset_keep_alive_timer(state)
         on_publish_release [message: message, state: state]
         {:noreply, state}
       end
@@ -201,7 +200,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.Subscribe{} = message}, state) do
-        state = update_keep_alive_timer(state)
+        state = reset_keep_alive_timer(state)
         on_subscribe [message: message, state: state]
         {:noreply, state}
       end
@@ -212,7 +211,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.Unsubscribe{} = message}, state) do
-        state = update_keep_alive_timer(state)
+        state = reset_keep_alive_timer(state)
         on_unsubscribe [message: message, state: state]
         {:noreply, state}
       end
@@ -223,7 +222,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.PingReq{} = message}, state) do
-        state = update_keep_alive_timer(state)
+        state = reset_keep_alive_timer(state)
         on_ping [message: message, state: state]
         {:noreply, state}
       end
@@ -234,7 +233,7 @@ defmodule Hulaaki.Client do
       end
 
       def handle_info({:sent, %Message.Disconnect{} = message}, state) do
-        state = update_keep_alive_timer(state)
+        state = reset_keep_alive_timer(state)
         on_disconnect [message: message, state: state]
         {:noreply, state}
       end
@@ -245,12 +244,9 @@ defmodule Hulaaki.Client do
       end
 
       ## Private functions
-      defp update_keep_alive_timer(%{keep_alive_interval: keep_alive_interval, keep_alive_timer_ref: keep_alive_timer_ref} = state) do
-        if keep_alive_timer_ref do
-          Process.cancel_timer(keep_alive_timer_ref)
-        end
-
-        keep_alive_timer_ref = Process.send_after(self, {:keep_alive}, keep_alive_interval)
+      defp reset_keep_alive_timer(%{keep_alive_interval: keep_alive_interval, keep_alive_timer_ref: keep_alive_timer_ref} = state) do
+        if keep_alive_timer_ref, do: Process.cancel_timer(keep_alive_timer_ref)
+        keep_alive_timer_ref = Process.send_after(self(), {:keep_alive}, keep_alive_interval)
         %{state | keep_alive_timer_ref: keep_alive_timer_ref}
       end
 

--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -49,6 +49,8 @@ defmodule Hulaaki.Client do
           state
           |> Map.put(:keep_alive_interval, nil)
           |> Map.put(:keep_alive_timer_ref, nil)
+          |> Map.put(:ping_response_timeout_interval, nil)
+          |> Map.put(:ping_response_timer_ref, nil)
         {:ok, state}
       end
 
@@ -73,6 +75,9 @@ defmodule Hulaaki.Client do
         clean_session = opts |> Keyword.get(:clean_session, 1)
         keep_alive    = opts |> Keyword.get(:keep_alive, 100)
 
+        # arbritary : based off recommendation on MQTT 3.1.1 spec Line 542/543
+        ping_response_timeout = keep_alive * 2
+
         message = Message.connect(client_id, username, password,
                                   will_topic, will_message, will_qos,
                                   will_retain, clean_session, keep_alive)
@@ -81,7 +86,8 @@ defmodule Hulaaki.Client do
 
         connect_opts = [host: host, port: port, timeout: timeout]
         case state.connection |> Connection.connect(message, connect_opts) do
-          :ok -> {:reply, :ok, %{state | keep_alive_interval: keep_alive * 1000}}
+          :ok -> {:reply, :ok, %{state | keep_alive_interval: keep_alive * 1000,
+                                         ping_response_timeout_interval: ping_response_timeout * 1000}}
           {:error, reason} -> {:reply, {:error, reason}, state}
         end
       end
@@ -223,11 +229,13 @@ defmodule Hulaaki.Client do
 
       def handle_info({:sent, %Message.PingReq{} = message}, state) do
         state = reset_keep_alive_timer(state)
+        state = reset_ping_response_timer(state)
         on_ping [message: message, state: state]
         {:noreply, state}
       end
 
       def handle_info({:received, %Message.PingResp{} = message}, state) do
+        state = cancel_ping_response_timer(state)
         on_ping_response [message: message, state: state]
         {:noreply, state}
       end
@@ -243,11 +251,27 @@ defmodule Hulaaki.Client do
         {:noreply, state}
       end
 
+      def handle_info({:ping_response_timeout}, state) do
+        on_ping_response_timeout [message: nil, state: state]
+        {:noreply, state}
+      end
+
       ## Private functions
       defp reset_keep_alive_timer(%{keep_alive_interval: keep_alive_interval, keep_alive_timer_ref: keep_alive_timer_ref} = state) do
         if keep_alive_timer_ref, do: Process.cancel_timer(keep_alive_timer_ref)
         keep_alive_timer_ref = Process.send_after(self(), {:keep_alive}, keep_alive_interval)
         %{state | keep_alive_timer_ref: keep_alive_timer_ref}
+      end
+
+      defp reset_ping_response_timer(%{ping_response_timeout_interval: ping_response_timeout_interval, ping_response_timer_ref: ping_response_timer_ref} = state) do
+        if ping_response_timer_ref, do: Process.cancel_timer(ping_response_timer_ref)
+        ping_response_timer_ref = Process.send_after(self(), {:ping_response_timeout}, ping_response_timeout_interval)
+        %{state | ping_response_timer_ref: ping_response_timer_ref}
+      end
+
+      defp cancel_ping_response_timer(%{ping_response_timer_ref: ping_response_timer_ref} = state) do
+        if ping_response_timer_ref, do: Process.cancel_timer(ping_response_timer_ref)
+        %{state | ping_response_timer_ref: nil}
       end
 
       ## Overrideable callbacks
@@ -267,6 +291,7 @@ defmodule Hulaaki.Client do
       def on_subscribed_publish_ack([message: message, state: state]), do: true
       def on_ping([message: message, state: state]), do: true
       def on_ping_response([message: message, state: state]), do: true
+      def on_ping_response_timeout([message: message, state: state]), do: true
       def on_disconnect([message: message, state: state]), do: true
 
       defoverridable [on_connect: 1, on_connect_ack: 1,
@@ -276,7 +301,7 @@ defmodule Hulaaki.Client do
                       on_subscribe: 1, on_subscribe_ack: 1,
                       on_unsubscribe: 1, on_unsubscribe_ack: 1,
                       on_subscribed_publish: 1, on_subscribed_publish_ack: 1,
-                      on_ping: 1, on_ping_response: 1,
+                      on_ping: 1, on_ping_response: 1, on_ping_response_timeout: 1,
                       on_disconnect: 1]
     end
   end

--- a/test/hulaaki/client_test.exs
+++ b/test/hulaaki/client_test.exs
@@ -242,6 +242,19 @@ defmodule Hulaaki.ClientTest do
     post_disconnect pid
   end
 
+  test "receives ping (and hence ping_response) after keep_alive timeout on idle connection" do
+    {:ok, pid} = SampleClient.start_link(%{parent: self()})
+
+    options = [client_id: "some-name-6379", host: TestConfig.mqtt_host, port: TestConfig.mqtt_port,
+               keep_alive: 2, timeout: 200]
+    SampleClient.connect(pid, options)
+
+    assert_receive({:ping, %Message.PingReq{}}, 4_000)
+    assert_receive({:ping_response, %Message.PingResp{}}, 4_000)
+
+    post_disconnect pid
+  end
+
   test "on_subscribed_publish callback on receiving publish on subscribed topic", %{client_pid: pid} do
     pre_connect pid
 

--- a/test/hulaaki/client_test.exs
+++ b/test/hulaaki/client_test.exs
@@ -76,7 +76,8 @@ defmodule Hulaaki.ClientTest do
   end
 
   defp pre_connect(pid) do
-    options = [client_id: "some-name", host: TestConfig.mqtt_host, port: TestConfig.mqtt_port, timeout: 200]
+    options = [client_id: "some-name" <> Integer.to_string(:rand.uniform(10_000)),
+               host: TestConfig.mqtt_host, port: TestConfig.mqtt_port, timeout: 200]
     SampleClient.connect(pid, options)
   end
 
@@ -86,7 +87,7 @@ defmodule Hulaaki.ClientTest do
   end
 
   test "error message when sending connect on connection failure", %{client_pid: pid} do
-    options = [client_id: "some-name", host: TestConfig.mqtt_host, port: 7878, timeout: 200]
+    options = [client_id: "some-name-1974", host: TestConfig.mqtt_host, port: 7878, timeout: 200]
 
     reply = SampleClient.connect(pid, options)
 
@@ -264,7 +265,7 @@ defmodule Hulaaki.ClientTest do
     spawn fn ->
       {:ok, pid2} = SampleClient.start_link(%{parent: self()})
 
-      options = [client_id: "another-name", host: TestConfig.mqtt_host, port: TestConfig.mqtt_port]
+      options = [client_id: "another-name-7592", host: TestConfig.mqtt_host, port: TestConfig.mqtt_port]
       SampleClient.connect(pid2, options)
 
       options = [id: 11_175, topic: "awesome", message: "a message",
@@ -288,7 +289,7 @@ defmodule Hulaaki.ClientTest do
     spawn fn ->
       {:ok, pid2} = SampleClient.start_link(%{parent: self()})
 
-      options = [client_id: "another-name", host: TestConfig.mqtt_host, port: TestConfig.mqtt_port]
+      options = [client_id: "another-name-8234", host: TestConfig.mqtt_host, port: TestConfig.mqtt_port]
       SampleClient.connect(pid2, options)
 
       options = [id: 11_175, topic: "awesome", message: "a message",

--- a/test/hulaaki/client_test.exs
+++ b/test/hulaaki/client_test.exs
@@ -61,8 +61,8 @@ defmodule Hulaaki.ClientTest do
       Kernel.send state.parent, {:ping, message}
     end
 
-    def on_pong(message: message, state: state) do
-      Kernel.send state.parent, {:pong, message}
+    def on_ping_response(message: message, state: state) do
+      Kernel.send state.parent, {:ping_response, message}
     end
 
     def on_disconnect(message: message, state: state) do
@@ -233,11 +233,11 @@ defmodule Hulaaki.ClientTest do
     post_disconnect pid
   end
 
-  test "on_pong callback on receiving ping_resp", %{client_pid: pid} do
+  test "on_ping_response callback on receiving ping_resp", %{client_pid: pid} do
     pre_connect pid
 
     SampleClient.ping(pid)
-    assert_receive {:pong, %Message.PingResp{}}
+    assert_receive {:ping_response, %Message.PingResp{}}
 
     post_disconnect pid
   end


### PR DESCRIPTION
- automatic ping server based on keep_alive if no other control packets sent (callback)
- get ping response from server (callback)
- ping response timeout from server (callback)