### PR TITLE
Make Client#stop also stop the connection if still active

### DIFF
--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -56,6 +56,10 @@ defmodule Hulaaki.Client do
       end
 
       def handle_call(:stop, _from, state) do
+        conn_pid = state.connection
+        if conn_pid && Process.alive?(conn_pid) do
+          Connection.stop(conn_pid)
+        end
         {:stop, :normal, :ok, state}
       end
 


### PR DESCRIPTION
Currently, if you call client#stop with an active connection, the client closes but leaves the connection alive and orphaned.