### PR TITLE
Fix compiler warning

### DIFF
--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -178,6 +178,7 @@ defmodule Hulaaki.Client do
             :ok = state.connection |> Connection.publish_ack(message)
           _ ->
             # unsure about supporting qos 2 yet
+            :noop
         end
 
         {:noreply, state}


### PR DESCRIPTION
Elixir compiler complains about this line : 

```
warning: an expression is always required on the right side of ->. Please provide a value after ->
  lib/hulaaki/client.ex:179
```