### PR TITLE
Increase default tcp/ssl connect timeout from 100ms to 4s

### DIFF
--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -68,7 +68,7 @@ defmodule Hulaaki.Client do
       def handle_call({:connect, opts, conn_pid}, _from, state) do
         host          = opts |> Keyword.fetch!(:host)
         port          = opts |> Keyword.fetch!(:port)
-        timeout       = opts |> Keyword.get(:timeout, 100)
+        timeout       = opts |> Keyword.get(:timeout, 10*1000)
         ssl           = opts |> Keyword.get(:ssl, false)
 
         client_id     = opts |> Keyword.fetch!(:client_id)


### PR DESCRIPTION
A 100ms tcp/ssl default connect timeout is fine for someone connecting to a server on localhost, but is very optimistic for connecting to a remote server. Especially with ssl and its 3-way handshake, which for a server across the globe can easily take several hundred milliseconds even in perfect conditions.  Someone who specifically wants a very low timeout due to a local server can always pass one in, but I'd argue that the default should be something reasonable for a wider set of usecases, say, a few seconds, which will reduce spurious `{:error, :timeout}` issues.