### PR TITLE
Add optional opts to client

### DIFF
--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -9,8 +9,8 @@ defmodule Hulaaki.Client do
       alias Hulaaki.Connection
       alias Hulaaki.Message
 
-      def start_link(initial_state) do
-        GenServer.start_link(__MODULE__, initial_state)
+      def start_link(initial_state, opts \\ []) do
+        GenServer.start_link(__MODULE__, initial_state, opts)
       end
 
       def stop(pid) do


### PR DESCRIPTION
First of all, Thank you for writing this lib. I'm just start to using it and I think will help me a lot.

This PR tries to solve one problem that I have using this lib, I'm using named processes as a way to control my MQTT connections, but I don't wanna use `Process.register(pid, name)`  everytime that I create a new MQTT connection, besides that I think a good option is the Redix(https://github.com/whatyouhide/redix/blob/master/lib/redix/connection.ex) strategy. This lib allows me to pass a name as a option.


<img width="431" alt="screen shot 2018-02-06 at 12 06 17" src="https://user-images.githubusercontent.com/5194287/35856401-34bc25d2-0b36-11e8-8dba-cc618e6f83cd.png">


What do you think about it? If you agree I can create a sanitize method to clean this opts when start_link is called.
