### PR TITLE
Link Connection process to Client process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 /deps
 erl_crash.dump
 *.ez
+
+# Ignore JetBrains IDE family (IntelliJ, PyCharm, etc.) project files
+*.iml
+.idea/

--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -9,6 +9,10 @@ defmodule Hulaaki.Client do
       alias Hulaaki.Connection
       alias Hulaaki.Message
 
+      def start(initial_state) do
+        GenServer.start(__MODULE__, initial_state)
+      end
+
       def start_link(initial_state) do
         GenServer.start_link(__MODULE__, initial_state)
       end
@@ -18,8 +22,7 @@ defmodule Hulaaki.Client do
       end
 
       def connect(pid, opts) do
-        {:ok, conn_pid} = Connection.start_link(pid)
-        GenServer.call(pid, {:connect, opts, conn_pid})
+        GenServer.call(pid, {:connect, opts})
       end
 
       def publish(pid, opts) do
@@ -68,7 +71,8 @@ defmodule Hulaaki.Client do
 
       # collection options for host port ?
 
-      def handle_call({:connect, opts, conn_pid}, _from, state) do
+      def handle_call({:connect, opts}, _from, state) do
+        {:ok, conn_pid} = Connection.start_link(self())
         host = opts |> Keyword.fetch!(:host)
         port = opts |> Keyword.fetch!(:port)
         timeout = opts |> Keyword.get(:timeout, 10 * 1000)

--- a/test/hulaaki/client_tcp_test.exs
+++ b/test/hulaaki/client_tcp_test.exs
@@ -107,7 +107,7 @@ defmodule Hulaaki.ClientTCPTest do
   end
 
   setup do
-    {:ok, pid} = SampleClient.start_link(%{parent: self()})
+    {:ok, pid} = SampleClient.start(%{parent: self()})
     {:ok, client_pid: pid}
   end
 
@@ -154,6 +154,18 @@ defmodule Hulaaki.ClientTCPTest do
     assert_receive {:connect_ack, %Message.ConnAck{}}
 
     post_disconnect(pid)
+  end
+
+  test "monitor client and receive :DOWN signal when connection killed", %{client_pid: pid} do
+    pre_connect(pid)
+
+    Process.monitor(pid)
+
+    %{connection: connection} = :sys.get_state(pid)
+
+    Process.exit(connection, :stop)
+
+    assert_receive {:DOWN, _ref, :process, ^pid, :stop}
   end
 
   test "on_disconnect callback on sending disconnect", %{client_pid: pid} do


### PR DESCRIPTION
Hi!

As discussed in #41, this enables recovering from a broken connection, by linking the `Connection` process to the `Client` process, instead of the caller process. This makes it enough to monitor only the `Client` process in order to recover from a broken connection.

In addition, I've added a `start` function in the `Hulaaki.Client` module in addition to the `start_link` function, so you don't have to unlink your process from the `Client` when monitoring it.

The unit test monitors the `Client` process, and manually kills the `Connection` process in order to test that the test gracefully receives a `:DOWN` notification by only monitoring the `Client` process. Before this change, the test process would simply die because it was linked to the `Connection` process which is killed.

I'm looking forward to your comments and suggestions.

Resolves #41 
