### PR TITLE
Support for Websocket Transport Layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       elixir: 1.5.3
     - otp_release: 20.2
       elixir: 1.6.0
+    - otp_release: 21.0
+      elixir: 1.7
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get -y install libc-ares-dev libssl-dev uuid-dev cmake

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM elixir:1.6.5-alpine
+FROM elixir:1.6.6-otp-21-alpine
 
 WORKDIR /usr/src/app
 
 COPY mix.exs mix.lock /usr/src/app/
 COPY config /usr/src/app/config
+
+RUN apk add --update git
 
 RUN mix do local.hex --force, local.rebar --force, deps.get, deps.compile
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ brokers(via the MQTT 3.1.1 protocol).
 
 A quick tour of the features implemented right now:
 - Qos 0 and Qos 1 support available. QoS 2 not supported yet.
-- SSL/TLS support available.
+- SSL/TLS and websockets support available.
 - Automatic Ping based on keep alive timeout.
 - Internal packet id generation for control packets with variable header.
 
@@ -38,7 +38,7 @@ callbacks that are intended to be overridden for required
 implementations. The callbacks are defined for each MQTT message that
 is being sent and received from the server.
 
-Here's a [list of all the override-able callbacks to](lib/hulaaki/client.ex#L292-L318)use in your projects.
+Here's a [list of all the override-able callbacks to](lib/hulaaki/client.ex#L405-L422)use in your projects.
 
 An example is present below that overrides some callbacks.
 
@@ -71,7 +71,7 @@ $ iex -S mix
 
 > {:ok, pid} = SampleClient.start_link(%{})
 
-> options = [client_id: "some-name-7490", host: "localhost", port: 8883, ssl: true]
+> options = [client_id: "some-name-7490", host: "localhost", port: 1883]
 
 > SampleClient.connect(pid, options)
 
@@ -89,6 +89,22 @@ Please check the [CHANGELOG.md](https://github.com/suvash/hulaaki/blob/master/CH
 
 ## Documentation
 
+### Transport Layer
+
+During connection establishment you can specify which transport layer you want and the transport specific options (check each dependency documentation to check available options).
+
+```
+> options = [client_id: "some-name-7490", host: "localhost", port: 8883, transport: Hulaaki.Transport.Websocket, transport_opts: [path: "/mqtt"]
+> SampleClient.connect(pid, options)
+```
+
+Supported transport layers
+- `Hulaaki.Transport.Ssl` - Uses [:ssl](http://erlang.org/doc/man/ssl.html)
+- `Hulaaki.Transport.Tcp` - Uses [:gen_tcp](http://erlang.org/doc/man/gen_tcp.html)
+- `Hulaaki.Transport.Websocket` - Uses [Socket.Web](https://hexdocs.pm/socket/Socket.Web.html)
+
+
+### Further documentation
 Please refer to the inline documentation and client tests to explore
 the documentation for now.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,18 @@
+---
 version: "3"
 services:
 
-  mqtt_server:
+  mqtt-server:
     image: eclipse-mosquitto:1.4.12
     restart: always
     volumes:
       - ./mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
       - ./mosquitto/certs/:/etc/mosquitto/certs/
     ports:
-      - "8083:1883"
-      - "8084:8883"
+      - "1883:1883"
+      - "8883:8883"
+      - "1884:1884"
+      - "8884:8884"
 
   hulaaki:
     build: .
@@ -19,10 +22,10 @@ services:
       - ./:/usr/src/app
       - /usr/src/app/deps
     depends_on:
-      - mqtt_server
-    links:
-      - mqtt_server:mqtt-host
+      - mqtt-server
     environment:
-      MQTT_HOST: mqtt-host
+      MQTT_HOST: mqtt-server
       MQTT_PORT: 1883
       MQTT_TLS_PORT: 8883
+      MQTT_WEBSOCKET_PORT: 1884
+      MQTT_WEBSOCKET_TLS_PORT: 8884

--- a/lib/hulaaki/application.ex
+++ b/lib/hulaaki/application.ex
@@ -1,0 +1,9 @@
+defmodule Hulaaki.Application do
+  use Application
+
+  def start(_type, _args) do
+    children = [{DynamicSupervisor, strategy: :one_for_one, name: Hulaaki.Connection.Supervisor}]
+    opts = [strategy: :one_for_one, name: Hulaaki.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/hulaaki/application.ex
+++ b/lib/hulaaki/application.ex
@@ -2,8 +2,18 @@ defmodule Hulaaki.Application do
   use Application
 
   def start(_type, _args) do
-    children = [{DynamicSupervisor, strategy: :one_for_one, name: Hulaaki.Connection.Supervisor}]
+    children = [System.version() |> String.slice(0..2) |> connection_supervisor_child_spec()]
+
     opts = [strategy: :one_for_one, name: Hulaaki.Supervisor]
+
     Supervisor.start_link(children, opts)
   end
+
+  defp connection_supervisor_child_spec("1.4") do
+    import Supervisor.Spec, only: [supervisor: 3]
+
+    supervisor(Hulaaki.Connection.Supervisor, [:ok], [])
+  end
+
+  defp connection_supervisor_child_spec(_), do: Hulaaki.Connection.Supervisor
 end

--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -73,6 +73,8 @@ defmodule Hulaaki.Client do
         port = opts |> Keyword.fetch!(:port)
         timeout = opts |> Keyword.get(:timeout, 10 * 1000)
         ssl = opts |> Keyword.get(:ssl, false)
+        transport = opts |> Keyword.get(:transport)
+        transport_opts = opts |> Keyword.get(:transport_opts)
 
         client_id = opts |> Keyword.fetch!(:client_id)
         username = opts |> Keyword.get(:username, "")
@@ -102,7 +104,14 @@ defmodule Hulaaki.Client do
 
         state = Map.merge(%{connection: conn_pid}, state)
 
-        connect_opts = [host: host, port: port, timeout: timeout, ssl: ssl]
+        connect_opts = [
+          host: host,
+          port: port,
+          timeout: timeout,
+          ssl: ssl,
+          transport: transport,
+          transport_opts: transport_opts
+        ]
 
         case state.connection |> Connection.connect(message, connect_opts) do
           :ok ->

--- a/lib/hulaaki/client.ex
+++ b/lib/hulaaki/client.ex
@@ -51,6 +51,7 @@ defmodule Hulaaki.Client do
           |> Map.put(:keep_alive_timer_ref, nil)
           |> Map.put(:ping_response_timeout_interval, nil)
           |> Map.put(:ping_response_timer_ref, nil)
+          |> Map.put(:connection, nil)
 
         {:ok, state}
       end
@@ -131,6 +132,10 @@ defmodule Hulaaki.Client do
           {:error, reason} ->
             {:reply, {:error, reason}, state}
         end
+      end
+
+      def handle_call(_, _from, %{connection: nil} = state) do
+        {:reply, {:error, :not_connected}, state}
       end
 
       def handle_call({:publish, opts}, _from, state) do

--- a/lib/hulaaki/connection/supervisor.ex
+++ b/lib/hulaaki/connection/supervisor.ex
@@ -1,0 +1,9 @@
+defmodule Hulaaki.Connection.Supervisor do
+  use Supervisor
+
+  def start_link(_) do
+    Supervisor.start_link([], strategy: :one_for_one, name: __MODULE__)
+  end
+
+  def init(_), do: :ok
+end

--- a/lib/hulaaki/transport.ex
+++ b/lib/hulaaki/transport.ex
@@ -1,0 +1,13 @@
+defmodule Hulaaki.Transport do
+  @type socket :: any
+  # @type port :: post_integer
+  @type packet :: any
+
+  @callback connect(host :: binary, port :: port, opts :: keyword, timeout :: pos_integer) ::
+              {:ok, Socket} | {:error, any}
+  @callback send(socket :: socket, packet :: packet) :: :ok | {:error, any}
+  @callback close(socket :: socket) :: :ok | {:error, any}
+  @callback set_active_once(socket :: socket) :: :ok | {:error, any}
+  @callback packet_message() :: atom()
+  @callback closing_message() :: atom()
+end

--- a/lib/hulaaki/transport/ssl.ex
+++ b/lib/hulaaki/transport/ssl.ex
@@ -1,0 +1,21 @@
+defmodule Hulaaki.Transport.Ssl do
+  def connect(host, port, opts, timeout) do
+    :ssl.connect(host, port, opts, timeout)
+  end
+
+  def send(socket, packet) do
+    :ssl.send(socket, packet)
+  end
+
+  def close(socket) do
+    :ssl.close(socket)
+  end
+
+  def set_active_once(socket) do
+    :ssl.setopts(socket, active: :once)
+    socket
+  end
+
+  def packet_message, do: :ssl
+  def closing_message, do: :ssl_closed
+end

--- a/lib/hulaaki/transport/tcp.ex
+++ b/lib/hulaaki/transport/tcp.ex
@@ -1,0 +1,21 @@
+defmodule Hulaaki.Transport.Tcp do
+  def connect(host, port, opts, timeout) do
+    :gen_tcp.connect(host, port, opts, timeout)
+  end
+
+  def send(socket, packet) do
+    :gen_tcp.send(socket, packet)
+  end
+
+  def close(socket) do
+    :gen_tcp.close(socket)
+  end
+
+  def set_active_once(socket) do
+    :inet.setopts(socket, active: :once)
+    socket
+  end
+
+  def packet_message, do: :tcp
+  def closing_message, do: :tcp_closed
+end

--- a/lib/hulaaki/transport/websocket.ex
+++ b/lib/hulaaki/transport/websocket.ex
@@ -22,8 +22,15 @@ defmodule Hulaaki.Transport.WebSocket do
     end
   end
 
-  def send(%{ws: ws} = _socket, packet) do
-    :ok = Socket.Web.send(ws, {:binary, packet})
+  def send(%{ws: ws, pid: pid} = _socket, packet) do
+    case Socket.Web.send(ws, {:binary, packet}) do
+      :ok ->
+        :ok
+
+      {:error, :closed} ->
+        GenServer.stop(pid, :normal)
+        {:error, :closed}
+    end
   end
 
   def close(%{ws: ws, pid: pid} = _socket) do

--- a/lib/hulaaki/transport/websocket.ex
+++ b/lib/hulaaki/transport/websocket.ex
@@ -1,0 +1,63 @@
+defmodule Hulaaki.Transport.WebSocket do
+  use GenServer
+  require Socket
+  @behaviour Hulaaki.Transport
+
+  @default_opts [path: "/", protocol: ["mqtt"]]
+
+  def connect(host, port, opts, timeout) do
+    with conn <- self(),
+         {:ok, ws} <-
+           Socket.Web.connect(
+             {to_string(host), port},
+             Keyword.new(@default_opts ++ opts ++ [timeout: timeout])
+           ),
+         socket <- %{ws: ws, conn: conn, pid: nil},
+         {:ok, pid} <- start_link(socket) do
+      Process.link(pid)
+      {:ok, %{socket | pid: pid}}
+    else
+      {:error, "connection refused"} -> {:error, :econnrefused}
+      err -> err
+    end
+  end
+
+  def send(%{ws: ws} = _socket, packet) do
+    :ok = Socket.Web.send(ws, {:binary, packet})
+  end
+
+  def close(%{ws: ws, pid: pid} = _socket) do
+    :ok = GenServer.stop(pid, :normal)
+    Socket.Web.close(ws)
+  end
+
+  def set_active_once(socket), do: socket
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args)
+  end
+
+  def init(state) do
+    GenServer.cast(self(), :receive)
+    {:ok, %{state | pid: self()}}
+  end
+
+  def handle_cast(:receive, %{ws: ws, conn: conn} = state) do
+    case Socket.Web.recv(ws) do
+      {:ok, {:binary, bitstring}} ->
+        Kernel.send(conn, {packet_message(), state, bitstring})
+        GenServer.cast(self(), :receive)
+        {:noreply, state}
+
+      {:ok, {:close, _, _}} ->
+        Kernel.send(conn, {closing_message(), state})
+        {:noreply, state}
+
+      error ->
+        {:stop, error, state}
+    end
+  end
+
+  def packet_message, do: :websocket
+  def closing_message, do: :websocket_closed
+end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Hulaaki.Mixfile do
       app: :hulaaki,
       version: @version,
       name: "Hulaaki",
-      elixir: "~> 1.3",
+      elixir: "~> 1.6",
       source_url: "https://github.com/suvash/hulaaki",
       homepage_url: "https://github.com/suvash/hulaaki",
       deps: deps(),
@@ -20,7 +20,7 @@ defmodule Hulaaki.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [applications: [], mod: {Hulaaki.Application, []}]
   end
 
   defp deps do

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,8 @@ defmodule Hulaaki.Mixfile do
       {:inch_ex, "~> 0.5", only: :docs},
       {:earmark, "~> 1.2", only: [:dev, :docs]},
       {:ex_doc, "~> 0.18", only: [:dev, :docs]},
-      {:excoveralls, "~> 0.8", only: [:dev, :test]}
+      {:excoveralls, "~> 0.8", only: [:dev, :test]},
+      {:socket, "~> 0.3"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Hulaaki.Mixfile do
       app: :hulaaki,
       version: @version,
       name: "Hulaaki",
-      elixir: "~> 1.6",
+      elixir: "~> 1.4",
       source_url: "https://github.com/suvash/hulaaki",
       homepage_url: "https://github.com/suvash/hulaaki",
       deps: deps(),

--- a/mix.lock
+++ b/mix.lock
@@ -12,6 +12,7 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }

--- a/mosquitto/mosquitto.conf
+++ b/mosquitto/mosquitto.conf
@@ -1,3 +1,25 @@
+port 1883
+protocol mqtt
+
+listener 8883
+protocol mqtt
+cafile /etc/mosquitto/certs/ca.crt
+certfile /etc/mosquitto/certs/server.crt
+keyfile /etc/mosquitto/certs/server.key
+tls_version tlsv1
+
+listener 1884
+protocol websockets
+
+listener 8884
+protocol websockets
+cafile /etc/mosquitto/certs/ca.crt
+certfile /etc/mosquitto/certs/server.crt
+keyfile /etc/mosquitto/certs/server.key
+tls_version tlsv1
+
+log_dest stdout
+
 # Config file for mosquitto
 #
 # See mosquitto.conf(5) for more information.
@@ -133,7 +155,7 @@
 #bind_address
 
 # Port to use for the default listener.
-port 1883
+# port 1883
 
 # The maximum number of client connections to allow. This is
 # a per listener setting.
@@ -274,7 +296,6 @@ port 1883
 # Note that for a websockets listener it is not possible to bind to a host
 # name.
 # listener port-number [ip address/host name]
-listener 8883
 
 # The maximum number of client connections to allow. This is
 # a per listener setting.
@@ -294,7 +315,7 @@ listener 8883
 # This can be either mqtt or websockets.
 # Certificate based TLS may be used with websockets, except that only the
 # cafile, certfile, keyfile and ciphers options are supported.
-protocol mqtt
+# protocol mqtt
 
 # When a listener is using the websockets protocol, it is possible to serve
 # http data as well. Set http_dir to a directory which contains the files you
@@ -332,21 +353,21 @@ protocol mqtt
 # containing the CA certificates. For capath to work correctly, the
 # certificate files must have ".crt" as the file ending and you must run
 # "c_rehash <path to capath>" each time you add/remove a certificate.
-cafile /etc/mosquitto/certs/ca.crt
+#cafile
 #capath
 
 # Path to the PEM encoded server certificate.
-certfile /etc/mosquitto/certs/server.crt
+#certfile
 
 # Path to the PEM encoded keyfile.
-keyfile /etc/mosquitto/certs/server.key
+#keyfile
 
 # This option defines the version of the TLS protocol to use for this listener.
 # The default value allows v1.2, v1.1 and v1.0, if they are all supported by
 # the version of openssl that the broker was compiled against. For openssl >=
 # 1.0.1 the valid values are tlsv1.2 tlsv1.1 and tlsv1. For openssl < 1.0.1 the
 # valid values are tlsv1.
-tls_version tlsv1
+#tls_version
 
 # By default an TLS enabled listener will operate in a similar fashion to a
 # https enabled web server, in that the server has a certificate signed by a CA
@@ -468,7 +489,7 @@ tls_version tlsv1
 # Note that if the broker is running as a Windows service it will default to
 # "log_dest none" and neither stdout nor stderr logging is available.
 # Use "log_dest none" if you wish to disable logging.
-log_dest stdout
+#log_dest
 
 # If using syslog logging (not on Windows), messages will be logged to the
 # "daemon" facility by default. Use the log_facility option to choose which of

--- a/test/hulaaki/client_ssl_test.exs
+++ b/test/hulaaki/client_ssl_test.exs
@@ -117,7 +117,7 @@ defmodule Hulaaki.ClientSSLTest do
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_tls_port(),
       timeout: TestConfig.mqtt_timeout(),
-      ssl: true
+      ssl: TestConfig.ssl_options()
     ]
 
     :ok = SampleClient.connect(pid, options)
@@ -134,7 +134,7 @@ defmodule Hulaaki.ClientSSLTest do
       host: TestConfig.mqtt_host(),
       port: 7878,
       timeout: TestConfig.mqtt_timeout(),
-      ssl: true
+      ssl: TestConfig.ssl_options()
     ]
 
     reply = SampleClient.connect(pid, options)
@@ -294,7 +294,7 @@ defmodule Hulaaki.ClientSSLTest do
       port: TestConfig.mqtt_tls_port(),
       keep_alive: 2,
       timeout: TestConfig.mqtt_timeout(),
-      ssl: true
+      ssl: TestConfig.ssl_options()
     ]
 
     SampleClient.connect(pid, options)
@@ -314,7 +314,7 @@ defmodule Hulaaki.ClientSSLTest do
       port: TestConfig.mqtt_tls_port(),
       keep_alive: 2,
       timeout: TestConfig.mqtt_timeout(),
-      ssl: true
+      ssl: TestConfig.ssl_options()
     ]
 
     HackPingResponseClient.connect(pid, options)
@@ -332,7 +332,7 @@ defmodule Hulaaki.ClientSSLTest do
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_tls_port(),
       timeout: TestConfig.mqtt_timeout(),
-      ssl: true
+      ssl: TestConfig.ssl_options()
     ]
 
     PacketIdInspectClient.connect(pid, options)
@@ -376,7 +376,7 @@ defmodule Hulaaki.ClientSSLTest do
         host: TestConfig.mqtt_host(),
         port: TestConfig.mqtt_tls_port(),
         timeout: TestConfig.mqtt_timeout(),
-        ssl: true
+        ssl: TestConfig.ssl_options()
       ]
 
       SampleClient.connect(pid2, options)
@@ -407,7 +407,7 @@ defmodule Hulaaki.ClientSSLTest do
         host: TestConfig.mqtt_host(),
         port: TestConfig.mqtt_tls_port(),
         timeout: TestConfig.mqtt_timeout(),
-        ssl: true
+        ssl: TestConfig.ssl_options()
       ]
 
       SampleClient.connect(pid2, options)

--- a/test/hulaaki/client_ssl_test.exs
+++ b/test/hulaaki/client_ssl_test.exs
@@ -120,7 +120,7 @@ defmodule Hulaaki.ClientSSLTest do
       ssl: true
     ]
 
-    SampleClient.connect(pid, options)
+    :ok = SampleClient.connect(pid, options)
   end
 
   defp post_disconnect(pid) do

--- a/test/hulaaki/client_ssl_test.exs
+++ b/test/hulaaki/client_ssl_test.exs
@@ -1,5 +1,5 @@
 defmodule Hulaaki.ClientSSLTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Hulaaki.Message
 
   defmodule SampleClient do
@@ -113,7 +113,7 @@ defmodule Hulaaki.ClientSSLTest do
 
   defp pre_connect(pid) do
     options = [
-      client_id: "some-name" <> Integer.to_string(:rand.uniform(10_000)),
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_tls_port(),
       timeout: TestConfig.mqtt_timeout(),
@@ -130,7 +130,7 @@ defmodule Hulaaki.ClientSSLTest do
 
   test "error message when sending connect on connection failure", %{client_pid: pid} do
     options = [
-      client_id: "some-name-1974",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: 7878,
       timeout: TestConfig.mqtt_timeout(),
@@ -145,7 +145,7 @@ defmodule Hulaaki.ClientSSLTest do
   test "on_connect callback on sending connect", %{client_pid: pid} do
     pre_connect(pid)
 
-    assert_receive {:connect, %Message.Connect{}}, 1_000
+    assert_receive {:connect, %Message.Connect{}}
 
     post_disconnect(pid)
   end
@@ -153,7 +153,7 @@ defmodule Hulaaki.ClientSSLTest do
   test "on_connect_ack callback on receiving connect_ack", %{client_pid: pid} do
     pre_connect(pid)
 
-    assert_receive {:connect_ack, %Message.ConnAck{}}, 1_000
+    assert_receive {:connect_ack, %Message.ConnAck{}}
 
     post_disconnect(pid)
   end
@@ -162,7 +162,7 @@ defmodule Hulaaki.ClientSSLTest do
     pre_connect(pid)
 
     SampleClient.disconnect(pid)
-    assert_receive {:disconnect, %Message.Disconnect{}}, 1_000
+    assert_receive {:disconnect, %Message.Disconnect{}}
 
     SampleClient.stop(pid)
   end
@@ -172,7 +172,7 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topic: "nope", message: "a message", dup: 0, qos: 1, retain: 1]
     SampleClient.publish(pid, options)
-    assert_receive {:publish, %Message.Publish{}}, 1_000
+    assert_receive {:publish, %Message.Publish{}}
 
     post_disconnect(pid)
   end
@@ -182,7 +182,7 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topic: "nope", message: "a message", dup: 0, qos: 0, retain: 1]
     SampleClient.publish(pid, options)
-    assert_receive {:publish, %Message.Publish{}}, 1_000
+    assert_receive {:publish, %Message.Publish{}}
 
     post_disconnect(pid)
   end
@@ -192,7 +192,7 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topic: "nope", message: "a message", dup: 0, qos: 1, retain: 1]
     SampleClient.publish(pid, options)
-    assert_receive {:publish_ack, %Message.PubAck{}}, 1_000
+    assert_receive {:publish_ack, %Message.PubAck{}}
 
     post_disconnect(pid)
   end
@@ -202,7 +202,7 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topic: "nope", message: "a message", dup: 0, qos: 2, retain: 1]
     SampleClient.publish(pid, options)
-    assert_receive {:publish_receive, %Message.PubRec{}}, 1_000
+    assert_receive {:publish_receive, %Message.PubRec{}}
 
     post_disconnect(pid)
   end
@@ -212,7 +212,7 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topic: "nope", message: "a message", dup: 0, qos: 2, retain: 1]
     SampleClient.publish(pid, options)
-    assert_receive {:publish_release, %Message.PubRel{}}, 1_000
+    assert_receive {:publish_release, %Message.PubRel{}}
 
     post_disconnect(pid)
   end
@@ -222,7 +222,7 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topic: "nope", message: "a message", dup: 0, qos: 2, retain: 1]
     SampleClient.publish(pid, options)
-    assert_receive {:publish_complete, %Message.PubComp{}}, 1_000
+    assert_receive {:publish_complete, %Message.PubComp{}}
 
     post_disconnect(pid)
   end
@@ -232,7 +232,7 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topics: ["a/b", "c/d"], qoses: [0, 1]]
     SampleClient.subscribe(pid, options)
-    assert_receive {:subscribe, %Message.Subscribe{}}, 1_000
+    assert_receive {:subscribe, %Message.Subscribe{}}
 
     post_disconnect(pid)
   end
@@ -242,7 +242,7 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topics: ["a/b", "c/d"], qoses: [0, 1]]
     SampleClient.subscribe(pid, options)
-    assert_receive {:subscribe_ack, %Message.SubAck{}}, 1_000
+    assert_receive {:subscribe_ack, %Message.SubAck{}}
 
     post_disconnect(pid)
   end
@@ -252,7 +252,7 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topics: ["a/d", "c/f"]]
     SampleClient.unsubscribe(pid, options)
-    assert_receive {:unsubscribe, %Message.Unsubscribe{}}, 1_000
+    assert_receive {:unsubscribe, %Message.Unsubscribe{}}
 
     post_disconnect(pid)
   end
@@ -262,7 +262,7 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topics: ["a/d", "c/f"]]
     SampleClient.unsubscribe(pid, options)
-    assert_receive {:unsubscribe_ack, %Message.UnsubAck{}}, 1_000
+    assert_receive {:unsubscribe_ack, %Message.UnsubAck{}}
 
     post_disconnect(pid)
   end
@@ -271,7 +271,7 @@ defmodule Hulaaki.ClientSSLTest do
     pre_connect(pid)
 
     SampleClient.ping(pid)
-    assert_receive {:ping, %Message.PingReq{}}, 1_000
+    assert_receive {:ping, %Message.PingReq{}}
 
     post_disconnect(pid)
   end
@@ -280,7 +280,7 @@ defmodule Hulaaki.ClientSSLTest do
     pre_connect(pid)
 
     SampleClient.ping(pid)
-    assert_receive {:ping_response, %Message.PingResp{}}, 1_000
+    assert_receive {:ping_response, %Message.PingResp{}}
 
     post_disconnect(pid)
   end
@@ -289,7 +289,7 @@ defmodule Hulaaki.ClientSSLTest do
     {:ok, pid} = SampleClient.start_link(%{parent: self()})
 
     options = [
-      client_id: "some-name-6379",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_tls_port(),
       keep_alive: 2,
@@ -309,7 +309,7 @@ defmodule Hulaaki.ClientSSLTest do
     {:ok, pid} = HackPingResponseClient.start_link(%{parent: self()})
 
     options = [
-      client_id: "ping-response-7402",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_tls_port(),
       keep_alive: 2,
@@ -328,7 +328,7 @@ defmodule Hulaaki.ClientSSLTest do
     {:ok, pid} = PacketIdInspectClient.start_link(%{parent: self()})
 
     options = [
-      client_id: "packet-inspect-9457",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_tls_port(),
       timeout: TestConfig.mqtt_timeout(),
@@ -339,23 +339,23 @@ defmodule Hulaaki.ClientSSLTest do
 
     options = [topic: "qos0", message: "a message", dup: 0, qos: 0, retain: 1]
     PacketIdInspectClient.publish(pid, options)
-    assert_receive {:publish, %Message.Publish{id: nil}}, 1_000
+    assert_receive {:publish, %Message.Publish{id: nil}}
 
     options = [topic: "qos1", message: "a message", dup: 0, qos: 1, retain: 1]
     PacketIdInspectClient.publish(pid, options)
-    assert_receive {:publish, %Message.Publish{id: 1}}, 1_000
+    assert_receive {:publish, %Message.Publish{id: 1}}
 
     options = [topic: "qos1", message: "a message", dup: 0, qos: 1, retain: 1]
     PacketIdInspectClient.publish(pid, options)
-    assert_receive {:publish, %Message.Publish{id: 2}}, 1_000
+    assert_receive {:publish, %Message.Publish{id: 2}}
 
     options = [topics: ["topicA", "topicB"], qoses: [0, 1]]
     PacketIdInspectClient.subscribe(pid, options)
-    assert_receive {:subscribe, %Message.Subscribe{id: 3}}, 1_000
+    assert_receive {:subscribe, %Message.Subscribe{id: 3}}
 
     options = [topics: ["topicA", "topicB"]]
     SampleClient.unsubscribe(pid, options)
-    assert_receive {:unsubscribe, %Message.Unsubscribe{id: 4}}, 1_000
+    assert_receive {:unsubscribe, %Message.Unsubscribe{id: 4}}
 
     post_disconnect(pid)
   end
@@ -372,7 +372,7 @@ defmodule Hulaaki.ClientSSLTest do
       {:ok, pid2} = SampleClient.start_link(%{parent: self()})
 
       options = [
-        client_id: "another-name-7592",
+        client_id: TestHelper.random_name(),
         host: TestConfig.mqtt_host(),
         port: TestConfig.mqtt_tls_port(),
         timeout: TestConfig.mqtt_timeout(),
@@ -387,7 +387,7 @@ defmodule Hulaaki.ClientSSLTest do
       post_disconnect(pid2)
     end)
 
-    assert_receive {:subscribed_publish, %Message.Publish{}}, 1_000
+    assert_receive {:subscribed_publish, %Message.Publish{}}
 
     post_disconnect(pid)
   end
@@ -403,7 +403,7 @@ defmodule Hulaaki.ClientSSLTest do
       {:ok, pid2} = SampleClient.start_link(%{parent: self()})
 
       options = [
-        client_id: "another-name-8234",
+        client_id: TestHelper.random_name(),
         host: TestConfig.mqtt_host(),
         port: TestConfig.mqtt_tls_port(),
         timeout: TestConfig.mqtt_timeout(),
@@ -418,7 +418,7 @@ defmodule Hulaaki.ClientSSLTest do
       post_disconnect(pid2)
     end)
 
-    assert_receive {:subscribed_publish_ack, %Message.PubAck{}}, 1_000
+    assert_receive {:subscribed_publish_ack, %Message.PubAck{}}
 
     post_disconnect(pid)
   end

--- a/test/hulaaki/client_tcp_test.exs
+++ b/test/hulaaki/client_tcp_test.exs
@@ -1,5 +1,5 @@
 defmodule Hulaaki.ClientTCPTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Hulaaki.Message
 
   defmodule SampleClient do
@@ -113,10 +113,10 @@ defmodule Hulaaki.ClientTCPTest do
 
   defp pre_connect(pid) do
     options = [
-      client_id: "some-name" <> Integer.to_string(:rand.uniform(10_000)),
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_port(),
-      timeout: 200
+      timeout: TestConfig.mqtt_timeout()
     ]
 
     :ok = SampleClient.connect(pid, options)
@@ -129,10 +129,10 @@ defmodule Hulaaki.ClientTCPTest do
 
   test "error message when sending connect on connection failure", %{client_pid: pid} do
     options = [
-      client_id: "some-name-1974",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: 7878,
-      timeout: 200
+      timeout: TestConfig.mqtt_timeout()
     ]
 
     reply = SampleClient.connect(pid, options)
@@ -287,11 +287,11 @@ defmodule Hulaaki.ClientTCPTest do
     {:ok, pid} = SampleClient.start_link(%{parent: self()})
 
     options = [
-      client_id: "some-name-6379",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_port(),
       keep_alive: 2,
-      timeout: 200
+      timeout: TestConfig.mqtt_timeout()
     ]
 
     SampleClient.connect(pid, options)
@@ -306,11 +306,11 @@ defmodule Hulaaki.ClientTCPTest do
     {:ok, pid} = HackPingResponseClient.start_link(%{parent: self()})
 
     options = [
-      client_id: "ping-response-7402",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_port(),
       keep_alive: 2,
-      timeout: 200
+      timeout: TestConfig.mqtt_timeout()
     ]
 
     HackPingResponseClient.connect(pid, options)
@@ -324,10 +324,10 @@ defmodule Hulaaki.ClientTCPTest do
     {:ok, pid} = PacketIdInspectClient.start_link(%{parent: self()})
 
     options = [
-      client_id: "packet-inspect-9457",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_port(),
-      timeout: 200
+      timeout: TestConfig.mqtt_timeout()
     ]
 
     PacketIdInspectClient.connect(pid, options)
@@ -367,7 +367,7 @@ defmodule Hulaaki.ClientTCPTest do
       {:ok, pid2} = SampleClient.start_link(%{parent: self()})
 
       options = [
-        client_id: "another-name-7592",
+        client_id: TestHelper.random_name(),
         host: TestConfig.mqtt_host(),
         port: TestConfig.mqtt_port()
       ]
@@ -396,7 +396,7 @@ defmodule Hulaaki.ClientTCPTest do
       {:ok, pid2} = SampleClient.start_link(%{parent: self()})
 
       options = [
-        client_id: "another-name-8234",
+        client_id: TestHelper.random_name(),
         host: TestConfig.mqtt_host(),
         port: TestConfig.mqtt_port()
       ]
@@ -425,7 +425,7 @@ defmodule Hulaaki.ClientTCPTest do
       {:ok, pid2} = SampleClient.start_link(%{parent: self()})
 
       options = [
-        client_id: "another-name-7629",
+        client_id: TestHelper.random_name(),
         host: TestConfig.mqtt_host(),
         port: TestConfig.mqtt_port()
       ]

--- a/test/hulaaki/client_tcp_test.exs
+++ b/test/hulaaki/client_tcp_test.exs
@@ -119,7 +119,7 @@ defmodule Hulaaki.ClientTCPTest do
       timeout: 200
     ]
 
-    SampleClient.connect(pid, options)
+    :ok = SampleClient.connect(pid, options)
   end
 
   defp post_disconnect(pid) do

--- a/test/hulaaki/client_tests.exs
+++ b/test/hulaaki/client_tests.exs
@@ -1,0 +1,110 @@
+defmodule Hulaaki.ClientTest do
+  use ExUnit.Case, async: true
+  alias Hulaaki.Message
+
+  defmodule SampleClient do
+    use Hulaaki.Client
+
+    def on_connect(message: message, state: state) do
+      Kernel.send(state.parent, {:connect, message})
+    end
+
+    def on_connect_ack(message: message, state: state) do
+      Kernel.send(state.parent, {:connect_ack, message})
+    end
+
+    def on_publish(message: message, state: state) do
+      Kernel.send(state.parent, {:publish, message})
+    end
+
+    def on_subscribed_publish(message: message, state: state) do
+      Kernel.send(state.parent, {:subscribed_publish, message})
+    end
+
+    def on_subscribed_publish_ack(message: message, state: state) do
+      Kernel.send(state.parent, {:subscribed_publish_ack, message})
+    end
+
+    def on_publish_receive(message: message, state: state) do
+      Kernel.send(state.parent, {:publish_receive, message})
+    end
+
+    def on_publish_release(message: message, state: state) do
+      Kernel.send(state.parent, {:publish_release, message})
+    end
+
+    def on_publish_complete(message: message, state: state) do
+      Kernel.send(state.parent, {:publish_complete, message})
+    end
+
+    def on_publish_ack(message: message, state: state) do
+      Kernel.send(state.parent, {:publish_ack, message})
+    end
+
+    def on_subscribe(message: message, state: state) do
+      Kernel.send(state.parent, {:subscribe, message})
+    end
+
+    def on_subscribe_ack(message: message, state: state) do
+      Kernel.send(state.parent, {:subscribe_ack, message})
+    end
+
+    def on_unsubscribe(message: message, state: state) do
+      Kernel.send(state.parent, {:unsubscribe, message})
+    end
+
+    def on_unsubscribe_ack(message: message, state: state) do
+      Kernel.send(state.parent, {:unsubscribe_ack, message})
+    end
+
+    def on_ping(message: message, state: state) do
+      Kernel.send(state.parent, {:ping, message})
+    end
+
+    def on_ping_response(message: message, state: state) do
+      Kernel.send(state.parent, {:ping_response, message})
+    end
+
+    def on_ping_response_timeout(message: message, state: state) do
+      Kernel.send(state.parent, {:ping_response_timeout, message})
+    end
+
+    def on_disconnect(message: message, state: state) do
+      Kernel.send(state.parent, {:disconnect, message})
+    end
+  end
+
+  setup do
+    {:ok, pid} = SampleClient.start_link(%{parent: self()})
+    {:ok, client_pid: pid}
+  end
+
+  defp pre_connect(pid) do
+    options = [
+      client_id: TestHelper.random_name(),
+      host: TestConfig.mqtt_host(),
+      port: TestConfig.mqtt_port(),
+      timeout: TestConfig.mqtt_timeout()
+    ]
+
+    :ok = SampleClient.connect(pid, options)
+  end
+
+  defp post_disconnect(pid) do
+    SampleClient.disconnect(pid)
+    SampleClient.stop(pid)
+  end
+
+  test "error message when sending message without connecting", %{client_pid: pid} do
+    options = [
+      client_id: TestHelper.random_name(),
+      host: TestConfig.mqtt_host(),
+      port: 7878,
+      timeout: TestConfig.mqtt_timeout()
+    ]
+
+    reply = SampleClient.ping(pid)
+
+    assert {:error, :not_connected} == reply
+  end
+end

--- a/test/hulaaki/client_websocket_test.exs
+++ b/test/hulaaki/client_websocket_test.exs
@@ -1,0 +1,468 @@
+defmodule Hulaaki.ClientWebsocketTest do
+  use ExUnit.Case
+  alias Hulaaki.Message
+
+  defmodule SampleClient do
+    use Hulaaki.Client
+
+    def on_connect(message: message, state: state) do
+      Kernel.send(state.parent, {:connect, message})
+    end
+
+    def on_connect_ack(message: message, state: state) do
+      Kernel.send(state.parent, {:connect_ack, message})
+    end
+
+    def on_publish(message: message, state: state) do
+      Kernel.send(state.parent, {:publish, message})
+    end
+
+    def on_subscribed_publish(message: message, state: state) do
+      Kernel.send(state.parent, {:subscribed_publish, message})
+    end
+
+    def on_subscribed_publish_ack(message: message, state: state) do
+      Kernel.send(state.parent, {:subscribed_publish_ack, message})
+    end
+
+    def on_publish_receive(message: message, state: state) do
+      Kernel.send(state.parent, {:publish_receive, message})
+    end
+
+    def on_publish_release(message: message, state: state) do
+      Kernel.send(state.parent, {:publish_release, message})
+    end
+
+    def on_publish_complete(message: message, state: state) do
+      Kernel.send(state.parent, {:publish_complete, message})
+    end
+
+    def on_publish_ack(message: message, state: state) do
+      Kernel.send(state.parent, {:publish_ack, message})
+    end
+
+    def on_subscribe(message: message, state: state) do
+      Kernel.send(state.parent, {:subscribe, message})
+    end
+
+    def on_subscribe_ack(message: message, state: state) do
+      Kernel.send(state.parent, {:subscribe_ack, message})
+    end
+
+    def on_unsubscribe(message: message, state: state) do
+      Kernel.send(state.parent, {:unsubscribe, message})
+    end
+
+    def on_unsubscribe_ack(message: message, state: state) do
+      Kernel.send(state.parent, {:unsubscribe_ack, message})
+    end
+
+    def on_ping(message: message, state: state) do
+      Kernel.send(state.parent, {:ping, message})
+    end
+
+    def on_ping_response(message: message, state: state) do
+      Kernel.send(state.parent, {:ping_response, message})
+    end
+
+    def on_ping_response_timeout(message: message, state: state) do
+      Kernel.send(state.parent, {:ping_response_timeout, message})
+    end
+
+    def on_disconnect(message: message, state: state) do
+      Kernel.send(state.parent, {:disconnect, message})
+    end
+  end
+
+  defmodule HackPingResponseClient do
+    use Hulaaki.Client
+
+    def on_ping(message: message, state: state) do
+      Kernel.send(state.parent, {:ping, message})
+    end
+
+    def on_ping_response(_) do
+      Kernel.send(self(), {:ping_response_timeout})
+    end
+
+    def on_ping_response_timeout(message: _, state: state) do
+      Kernel.send(state.parent, {:ping_response_timeout})
+    end
+  end
+
+  defmodule PacketIdInspectClient do
+    use Hulaaki.Client
+
+    def on_publish(message: message, state: state) do
+      Kernel.send(state.parent, {:publish, message})
+    end
+
+    def on_subscribe(message: message, state: state) do
+      Kernel.send(state.parent, {:subscribe, message})
+    end
+
+    def on_unsubscribe(message: message, state: state) do
+      Kernel.send(state.parent, {:unsubscribe, message})
+    end
+  end
+
+  setup do
+    {:ok, pid} = SampleClient.start_link(%{parent: self()})
+    {:ok, client_pid: pid}
+  end
+
+  defp pre_connect(pid) do
+    options = [
+      client_id: "some-name" <> Integer.to_string(:rand.uniform(10_000)),
+      host: TestConfig.mqtt_host(),
+      port: TestConfig.mqtt_websocket_port(),
+      timeout: 2000,
+      transport: Hulaaki.Transport.WebSocket,
+      transport_opts: []
+    ]
+
+    :ok = SampleClient.connect(pid, options)
+  end
+
+  defp post_disconnect(pid) do
+    SampleClient.disconnect(pid)
+    SampleClient.stop(pid)
+  end
+
+  test "error message when sending connect on connection failure", %{client_pid: pid} do
+    options = [
+      client_id: "some-name-1974",
+      host: TestConfig.mqtt_host(),
+      port: 7878,
+      timeout: 200,
+      transport: Hulaaki.Transport.WebSocket,
+      transport_opts: []
+    ]
+
+    reply = SampleClient.connect(pid, options)
+
+    assert {:error, :timeout} == reply
+  end
+
+  test "on_connect callback on sending connect", %{client_pid: pid} do
+    pre_connect(pid)
+
+    assert_receive {:connect, %Message.Connect{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_connect_ack callback on receiving connect_ack", %{client_pid: pid} do
+    pre_connect(pid)
+
+    assert_receive {:connect_ack, %Message.ConnAck{}}, 500
+
+    post_disconnect(pid)
+  end
+
+  test "on_disconnect callback on sending disconnect", %{client_pid: pid} do
+    pre_connect(pid)
+
+    SampleClient.disconnect(pid)
+    assert_receive {:disconnect, %Message.Disconnect{}}
+
+    SampleClient.stop(pid)
+  end
+
+  test "on_publish callback on sending publish", %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topic: "nope", message: "a message", dup: 0, qos: 1, retain: 1]
+    SampleClient.publish(pid, options)
+    assert_receive {:publish, %Message.Publish{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_publish callback on sending publish w. qos 0", %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topic: "nope", message: "a message", dup: 0, qos: 0, retain: 1]
+    SampleClient.publish(pid, options)
+    assert_receive {:publish, %Message.Publish{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_publish_ack callback on receiving publish_ack", %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topic: "nope", message: "a message", dup: 0, qos: 1, retain: 1]
+    SampleClient.publish(pid, options)
+    assert_receive {:publish_ack, %Message.PubAck{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_publish_receive callback on receiving publish_receive", %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topic: "nope", message: "a message", dup: 0, qos: 2, retain: 1]
+    SampleClient.publish(pid, options)
+    assert_receive {:publish_receive, %Message.PubRec{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_publish_release callback on sending publish_release", %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topic: "nope", message: "a message", dup: 0, qos: 2, retain: 1]
+    SampleClient.publish(pid, options)
+    assert_receive {:publish_release, %Message.PubRel{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_publish_complete callback on receiving publish_complete", %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topic: "nope", message: "a message", dup: 0, qos: 2, retain: 1]
+    SampleClient.publish(pid, options)
+    assert_receive {:publish_complete, %Message.PubComp{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_subscribe callback on sending subscribe", %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topics: ["a/b", "c/d"], qoses: [0, 1]]
+    SampleClient.subscribe(pid, options)
+    assert_receive {:subscribe, %Message.Subscribe{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_subscribe_ack callback on receiving subscribe_ack", %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topics: ["a/b", "c/d"], qoses: [0, 1]]
+    SampleClient.subscribe(pid, options)
+    assert_receive {:subscribe_ack, %Message.SubAck{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_unsubscribe callback on sending unsubscribe", %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topics: ["a/d", "c/f"]]
+    SampleClient.unsubscribe(pid, options)
+    assert_receive {:unsubscribe, %Message.Unsubscribe{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_unsubscribe_ack callback on receiving unsubscribe_ack", %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topics: ["a/d", "c/f"]]
+    SampleClient.unsubscribe(pid, options)
+    assert_receive {:unsubscribe_ack, %Message.UnsubAck{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_ping callback on sending ping", %{client_pid: pid} do
+    pre_connect(pid)
+
+    SampleClient.ping(pid)
+    assert_receive {:ping, %Message.PingReq{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_ping_response callback on receiving ping_resp", %{client_pid: pid} do
+    pre_connect(pid)
+
+    SampleClient.ping(pid)
+    assert_receive {:ping_response, %Message.PingResp{}}
+
+    post_disconnect(pid)
+  end
+
+  test "receives ping (and hence ping_response) after keep_alive timeout on idle connection" do
+    {:ok, pid} = SampleClient.start_link(%{parent: self()})
+
+    options = [
+      client_id: "some-name-6379",
+      host: TestConfig.mqtt_host(),
+      port: TestConfig.mqtt_websocket_port(),
+      keep_alive: 2,
+      timeout: 2000,
+      transport: Hulaaki.Transport.WebSocket,
+      transport_opts: []
+    ]
+
+    SampleClient.connect(pid, options)
+
+    assert_receive({:ping, %Message.PingReq{}}, 4_000)
+    assert_receive({:ping_response, %Message.PingResp{}}, 4_000)
+
+    post_disconnect(pid)
+  end
+
+  test "receives ping response timeout after the ping response timeout" do
+    {:ok, pid} = HackPingResponseClient.start_link(%{parent: self()})
+
+    options = [
+      client_id: "ping-response-7402",
+      host: TestConfig.mqtt_host(),
+      port: TestConfig.mqtt_websocket_port(),
+      keep_alive: 2,
+      timeout: 2000,
+      transport: Hulaaki.Transport.WebSocket,
+      transport_opts: []
+    ]
+
+    HackPingResponseClient.connect(pid, options)
+
+    assert_receive({:ping_response_timeout}, 8_000)
+
+    post_disconnect(pid)
+  end
+
+  test "packet id is incremented internally" do
+    {:ok, pid} = PacketIdInspectClient.start_link(%{parent: self()})
+
+    options = [
+      client_id: "packet-inspect-9457",
+      host: TestConfig.mqtt_host(),
+      port: TestConfig.mqtt_websocket_port(),
+      timeout: 2000,
+      transport: Hulaaki.Transport.WebSocket,
+      transport_opts: []
+    ]
+
+    PacketIdInspectClient.connect(pid, options)
+
+    options = [topic: "qos0", message: "a message", dup: 0, qos: 0, retain: 1]
+    PacketIdInspectClient.publish(pid, options)
+    assert_receive {:publish, %Message.Publish{id: nil}}
+
+    options = [topic: "qos1", message: "a message", dup: 0, qos: 1, retain: 1]
+    PacketIdInspectClient.publish(pid, options)
+    assert_receive {:publish, %Message.Publish{id: 1}}
+
+    options = [topic: "qos1", message: "a message", dup: 0, qos: 1, retain: 1]
+    PacketIdInspectClient.publish(pid, options)
+    assert_receive {:publish, %Message.Publish{id: 2}}
+
+    options = [topics: ["topicA", "topicB"], qoses: [0, 1]]
+    PacketIdInspectClient.subscribe(pid, options)
+    assert_receive {:subscribe, %Message.Subscribe{id: 3}}
+
+    options = [topics: ["topicA", "topicB"]]
+    SampleClient.unsubscribe(pid, options)
+    assert_receive {:unsubscribe, %Message.Unsubscribe{id: 4}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_subscribed_publish callback on receiving publish on subscribed topic", %{
+    client_pid: pid
+  } do
+    pre_connect(pid)
+
+    options = [topics: ["awesome"], qoses: [0]]
+    SampleClient.subscribe(pid, options)
+
+    spawn(fn ->
+      {:ok, pid2} = SampleClient.start_link(%{parent: self()})
+
+      options = [
+        client_id: "another-name-7592",
+        host: TestConfig.mqtt_host(),
+        port: TestConfig.mqtt_websocket_port(),
+        transport: Hulaaki.Transport.WebSocket,
+        transport_opts: []
+      ]
+
+      SampleClient.connect(pid2, options)
+
+      options = [topic: "awesome", message: "a message", dup: 0, qos: 0, retain: 1]
+      SampleClient.publish(pid2, options)
+
+      post_disconnect(pid2)
+    end)
+
+    assert_receive {:subscribed_publish, %Message.Publish{}}
+
+    post_disconnect(pid)
+  end
+
+  test "on_subscribed_publish_ack callback on sending publish ack after receiving publish on a subscribed topic",
+       %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topics: ["awesome"], qoses: [1]]
+    SampleClient.subscribe(pid, options)
+
+    spawn(fn ->
+      {:ok, pid2} = SampleClient.start_link(%{parent: self()})
+
+      options = [
+        client_id: "another-name-8234",
+        host: TestConfig.mqtt_host(),
+        port: TestConfig.mqtt_websocket_port(),
+        transport: Hulaaki.Transport.WebSocket,
+        transport_opts: []
+      ]
+
+      SampleClient.connect(pid2, options)
+
+      options = [topic: "awesome", message: "a message", dup: 0, qos: 1, retain: 1]
+      SampleClient.publish(pid2, options)
+
+      post_disconnect(pid2)
+    end)
+
+    assert_receive {:subscribed_publish_ack, %Message.PubAck{}}
+
+    post_disconnect(pid)
+  end
+
+  test "when qos 2, subscribed_publish and subscribed_publish_ack aren't called back, essential a :noop",
+       %{client_pid: pid} do
+    pre_connect(pid)
+
+    options = [topics: ["qos-1-topic", "qos-2-topic"], qoses: [1, 2]]
+    SampleClient.subscribe(pid, options)
+
+    spawn(fn ->
+      {:ok, pid2} = SampleClient.start_link(%{parent: self()})
+
+      options = [
+        client_id: "another-name-7629",
+        host: TestConfig.mqtt_host(),
+        port: TestConfig.mqtt_websocket_port(),
+        transport: Hulaaki.Transport.WebSocket,
+        transport_opts: []
+      ]
+
+      SampleClient.connect(pid2, options)
+
+      options_qos_1 = [topic: "qos-1-topic", message: "qos 1 here", dup: 0, qos: 1, retain: 0]
+      SampleClient.publish(pid2, options_qos_1)
+
+      options_qos_2 = [topic: "qos-2-topic", message: "qos 2 here", dup: 0, qos: 2, retain: 0]
+      SampleClient.publish(pid2, options_qos_2)
+
+      post_disconnect(pid2)
+    end)
+
+    assert_receive {:subscribed_publish, %Message.Publish{id: 1, message: "qos 1 here"}}
+    assert_receive {:subscribed_publish_ack, %Message.PubAck{id: 1}}
+
+    refute_receive {:subscribed_publish, %Message.Publish{message: "qos 2 here"}}
+    refute_receive {:subscribed_publish_ack, %Message.PubAck{id: 2}}
+
+    post_disconnect(pid)
+  end
+end

--- a/test/hulaaki/client_websocket_test.exs
+++ b/test/hulaaki/client_websocket_test.exs
@@ -1,5 +1,5 @@
 defmodule Hulaaki.ClientWebsocketTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Hulaaki.Message
 
   defmodule SampleClient do
@@ -113,10 +113,10 @@ defmodule Hulaaki.ClientWebsocketTest do
 
   defp pre_connect(pid) do
     options = [
-      client_id: "some-name" <> Integer.to_string(:rand.uniform(10_000)),
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_websocket_port(),
-      timeout: 2000,
+      timeout: TestConfig.mqtt_timeout(),
       transport: Hulaaki.Transport.WebSocket,
       transport_opts: []
     ]
@@ -131,7 +131,7 @@ defmodule Hulaaki.ClientWebsocketTest do
 
   test "error message when sending connect on connection failure", %{client_pid: pid} do
     options = [
-      client_id: "some-name-1974",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: 7878,
       timeout: 200,
@@ -141,7 +141,7 @@ defmodule Hulaaki.ClientWebsocketTest do
 
     reply = SampleClient.connect(pid, options)
 
-    assert {:error, :timeout} == reply
+    assert {:error, :econnrefused} == reply
   end
 
   test "on_connect callback on sending connect", %{client_pid: pid} do
@@ -155,7 +155,7 @@ defmodule Hulaaki.ClientWebsocketTest do
   test "on_connect_ack callback on receiving connect_ack", %{client_pid: pid} do
     pre_connect(pid)
 
-    assert_receive {:connect_ack, %Message.ConnAck{}}, 500
+    assert_receive {:connect_ack, %Message.ConnAck{}}
 
     post_disconnect(pid)
   end
@@ -291,11 +291,11 @@ defmodule Hulaaki.ClientWebsocketTest do
     {:ok, pid} = SampleClient.start_link(%{parent: self()})
 
     options = [
-      client_id: "some-name-6379",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_websocket_port(),
       keep_alive: 2,
-      timeout: 2000,
+      timeout: TestConfig.mqtt_timeout(),
       transport: Hulaaki.Transport.WebSocket,
       transport_opts: []
     ]
@@ -312,11 +312,11 @@ defmodule Hulaaki.ClientWebsocketTest do
     {:ok, pid} = HackPingResponseClient.start_link(%{parent: self()})
 
     options = [
-      client_id: "ping-response-7402",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_websocket_port(),
       keep_alive: 2,
-      timeout: 2000,
+      timeout: TestConfig.mqtt_timeout(),
       transport: Hulaaki.Transport.WebSocket,
       transport_opts: []
     ]
@@ -332,10 +332,10 @@ defmodule Hulaaki.ClientWebsocketTest do
     {:ok, pid} = PacketIdInspectClient.start_link(%{parent: self()})
 
     options = [
-      client_id: "packet-inspect-9457",
+      client_id: TestHelper.random_name(),
       host: TestConfig.mqtt_host(),
       port: TestConfig.mqtt_websocket_port(),
-      timeout: 2000,
+      timeout: TestConfig.mqtt_timeout(),
       transport: Hulaaki.Transport.WebSocket,
       transport_opts: []
     ]
@@ -377,7 +377,7 @@ defmodule Hulaaki.ClientWebsocketTest do
       {:ok, pid2} = SampleClient.start_link(%{parent: self()})
 
       options = [
-        client_id: "another-name-7592",
+        client_id: TestHelper.random_name(),
         host: TestConfig.mqtt_host(),
         port: TestConfig.mqtt_websocket_port(),
         transport: Hulaaki.Transport.WebSocket,
@@ -408,7 +408,7 @@ defmodule Hulaaki.ClientWebsocketTest do
       {:ok, pid2} = SampleClient.start_link(%{parent: self()})
 
       options = [
-        client_id: "another-name-8234",
+        client_id: TestHelper.random_name(),
         host: TestConfig.mqtt_host(),
         port: TestConfig.mqtt_websocket_port(),
         transport: Hulaaki.Transport.WebSocket,
@@ -439,7 +439,7 @@ defmodule Hulaaki.ClientWebsocketTest do
       {:ok, pid2} = SampleClient.start_link(%{parent: self()})
 
       options = [
-        client_id: "another-name-7629",
+        client_id: TestHelper.random_name(),
         host: TestConfig.mqtt_host(),
         port: TestConfig.mqtt_websocket_port(),
         transport: Hulaaki.Transport.WebSocket,

--- a/test/hulaaki/connection_ssl_test.exs
+++ b/test/hulaaki/connection_ssl_test.exs
@@ -1,28 +1,15 @@
 defmodule Hulaaki.ConnectionSSLTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Hulaaki.Connection
   alias Hulaaki.Message
 
-  # How to test disconnect message
-
-  defp client_name do
-    adjectives = ["lazy", "funny", "bright", "boring", "crazy", "lonely"]
-    nouns = ["thermometer", "switch", "scale", "bulb", "heater", "microwave"]
-
-    id = to_string(:rand.uniform(100_000))
-    [adjective] = adjectives |> Enum.shuffle() |> Enum.take(1)
-    [noun] = nouns |> Enum.shuffle() |> Enum.take(1)
-
-    adjective <> "-" <> noun <> "-" <> id
-  end
-
   setup do
-    {:ok, pid} = Connection.start_link(self())
+    {:ok, pid} = Connection.start(self())
     {:ok, connection_pid: pid}
   end
 
   defp pre_connect(pid) do
-    message = Message.connect(client_name(), "", "", "", "", 0, 0, 0, 100)
+    message = Message.connect(TestHelper.random_name(), "", "", "", "", 0, 0, 0, 100)
 
     :ok =
       Connection.connect(
@@ -41,7 +28,7 @@ defmodule Hulaaki.ConnectionSSLTest do
   end
 
   test "failed ssl connection returns an error tuple", %{connection_pid: pid} do
-    message = Message.connect(client_name(), "", "", "", "", 0, 0, 0, 100)
+    message = Message.connect(TestHelper.random_name(), "", "", "", "", 0, 0, 0, 100)
 
     reply =
       Connection.connect(
@@ -60,10 +47,9 @@ defmodule Hulaaki.ConnectionSSLTest do
     pre_connect(pid)
 
     assert_receive {:received,
-                    %Message.ConnAck{return_code: 0, session_present: 0, type: :CONNACK}},
-                   30_000
+                    %Message.ConnAck{return_code: 0, session_present: 0, type: :CONNACK}}
 
-    assert_receive {:sent, %Message.Connect{}}, 30_000
+    assert_receive {:sent, %Message.Connect{}}
 
     post_disconnect(pid)
   end
@@ -81,8 +67,8 @@ defmodule Hulaaki.ConnectionSSLTest do
 
     Connection.publish(pid, message)
 
-    assert_receive {:received, %Message.PubAck{id: 1122, type: :PUBACK}}, 30_000
-    assert_receive {:sent, %Message.Publish{}}, 30_000
+    assert_receive {:received, %Message.PubAck{id: 1122, type: :PUBACK}}
+    assert_receive {:sent, %Message.Publish{}}
 
     post_disconnect(pid)
   end
@@ -102,15 +88,15 @@ defmodule Hulaaki.ConnectionSSLTest do
 
     Connection.publish(pid, publish_message)
 
-    assert_receive {:received, %Message.PubRec{id: 2345, type: :PUBREC}}, 30_000
-    assert_receive {:sent, %Message.Publish{}}, 30_000
+    assert_receive {:received, %Message.PubRec{id: 2345, type: :PUBREC}}
+    assert_receive {:sent, %Message.Publish{}}
 
     publish_release_message = Message.publish_release(id)
 
     Connection.publish_release(pid, publish_release_message)
 
-    assert_receive {:received, %Message.PubComp{id: 2345, type: :PUBCOMP}}, 30_000
-    assert_receive {:sent, %Message.PubRel{}}, 30_000
+    assert_receive {:received, %Message.PubComp{id: 2345, type: :PUBCOMP}}
+    assert_receive {:sent, %Message.PubRel{}}
 
     post_disconnect(pid)
   end
@@ -125,10 +111,8 @@ defmodule Hulaaki.ConnectionSSLTest do
 
     Connection.subscribe(pid, message)
 
-    assert_receive {:received, %Message.SubAck{granted_qoses: [1, 2], id: 34875, type: :SUBACK}},
-                   30_000
-
-    assert_receive {:sent, %Message.Subscribe{}}, 30_000
+    assert_receive {:received, %Message.SubAck{granted_qoses: [1, 2], id: 34875, type: :SUBACK}}
+    assert_receive {:sent, %Message.Subscribe{}}
 
     post_disconnect(pid)
   end
@@ -142,8 +126,8 @@ defmodule Hulaaki.ConnectionSSLTest do
 
     Connection.unsubscribe(pid, message)
 
-    assert_receive {:received, %Message.UnsubAck{id: 19234, type: :UNSUBACK}}, 30_000
-    assert_receive {:sent, %Message.Unsubscribe{}}, 30_000
+    assert_receive {:received, %Message.UnsubAck{id: 19234, type: :UNSUBACK}}
+    assert_receive {:sent, %Message.Unsubscribe{}}
 
     post_disconnect(pid)
   end
@@ -153,8 +137,8 @@ defmodule Hulaaki.ConnectionSSLTest do
 
     Connection.ping(pid)
 
-    assert_receive {:received, %Message.PingResp{type: :PINGRESP}}, 30_000
-    assert_receive {:sent, %Message.PingReq{}}, 30_000
+    assert_receive {:received, %Message.PingResp{type: :PINGRESP}}
+    assert_receive {:sent, %Message.PingReq{}}
 
     post_disconnect(pid)
   end

--- a/test/hulaaki/connection_ssl_test.exs
+++ b/test/hulaaki/connection_ssl_test.exs
@@ -24,14 +24,15 @@ defmodule Hulaaki.ConnectionSSLTest do
   defp pre_connect(pid) do
     message = Message.connect(client_name(), "", "", "", "", 0, 0, 0, 100)
 
-    Connection.connect(
-      pid,
-      message,
-      host: TestConfig.mqtt_host(),
-      port: TestConfig.mqtt_tls_port(),
-      timeout: TestConfig.mqtt_timeout(),
-      ssl: true
-    )
+    :ok =
+      Connection.connect(
+        pid,
+        message,
+        host: TestConfig.mqtt_host(),
+        port: TestConfig.mqtt_tls_port(),
+        timeout: TestConfig.mqtt_timeout(),
+        ssl: TestConfig.ssl_options()
+      )
   end
 
   defp post_disconnect(pid) do
@@ -49,7 +50,7 @@ defmodule Hulaaki.ConnectionSSLTest do
         host: TestConfig.mqtt_host(),
         port: 7878,
         timeout: TestConfig.mqtt_timeout(),
-        ssl: true
+        ssl: TestConfig.ssl_options()
       )
 
     assert {:error, :econnrefused} == reply

--- a/test/hulaaki/connection_tcp_test.exs
+++ b/test/hulaaki/connection_tcp_test.exs
@@ -1,28 +1,15 @@
 defmodule Hulaaki.ConnectionTCPTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Hulaaki.Connection
   alias Hulaaki.Message
 
-  # How to test disconnect message
-
-  defp client_name do
-    adjectives = ["lazy", "funny", "bright", "boring", "crazy", "lonely"]
-    nouns = ["thermometer", "switch", "scale", "bulb", "heater", "microwave"]
-
-    id = to_string(:rand.uniform(100_000))
-    [adjective] = adjectives |> Enum.shuffle() |> Enum.take(1)
-    [noun] = nouns |> Enum.shuffle() |> Enum.take(1)
-
-    adjective <> "-" <> noun <> "-" <> id
-  end
-
   setup do
-    {:ok, pid} = Connection.start_link(self())
+    {:ok, pid} = Connection.start(self())
     {:ok, connection_pid: pid}
   end
 
   defp pre_connect(pid) do
-    message = Message.connect(client_name(), "", "", "", "", 0, 0, 0, 100)
+    message = Message.connect(TestHelper.random_name(), "", "", "", "", 0, 0, 0, 100)
 
     :ok =
       Connection.connect(
@@ -41,7 +28,7 @@ defmodule Hulaaki.ConnectionTCPTest do
   end
 
   test "failed tcp connection returns an error tuple", %{connection_pid: pid} do
-    message = Message.connect(client_name(), "", "", "", "", 0, 0, 0, 100)
+    message = Message.connect(TestHelper.random_name(), "", "", "", "", 0, 0, 0, 100)
 
     reply =
       Connection.connect(
@@ -60,10 +47,9 @@ defmodule Hulaaki.ConnectionTCPTest do
     pre_connect(pid)
 
     assert_receive {:received,
-                    %Message.ConnAck{return_code: 0, session_present: 0, type: :CONNACK}},
-                   500
+                    %Message.ConnAck{return_code: 0, session_present: 0, type: :CONNACK}}
 
-    assert_receive {:sent, %Message.Connect{}}, 500
+    assert_receive {:sent, %Message.Connect{}}
 
     post_disconnect(pid)
   end
@@ -81,8 +67,8 @@ defmodule Hulaaki.ConnectionTCPTest do
 
     Connection.publish(pid, message)
 
-    assert_receive {:received, %Message.PubAck{id: 1122, type: :PUBACK}}, 500
-    assert_receive {:sent, %Message.Publish{}}, 500
+    assert_receive {:received, %Message.PubAck{id: 1122, type: :PUBACK}}
+    assert_receive {:sent, %Message.Publish{}}
 
     post_disconnect(pid)
   end
@@ -102,15 +88,15 @@ defmodule Hulaaki.ConnectionTCPTest do
 
     Connection.publish(pid, publish_message)
 
-    assert_receive {:received, %Message.PubRec{id: 2345, type: :PUBREC}}, 500
-    assert_receive {:sent, %Message.Publish{}}, 500
+    assert_receive {:received, %Message.PubRec{id: 2345, type: :PUBREC}}
+    assert_receive {:sent, %Message.Publish{}}
 
     publish_release_message = Message.publish_release(id)
 
     Connection.publish_release(pid, publish_release_message)
 
-    assert_receive {:received, %Message.PubComp{id: 2345, type: :PUBCOMP}}, 500
-    assert_receive {:sent, %Message.PubRel{}}, 500
+    assert_receive {:received, %Message.PubComp{id: 2345, type: :PUBCOMP}}
+    assert_receive {:sent, %Message.PubRel{}}
 
     post_disconnect(pid)
   end
@@ -125,10 +111,8 @@ defmodule Hulaaki.ConnectionTCPTest do
 
     Connection.subscribe(pid, message)
 
-    assert_receive {:received, %Message.SubAck{granted_qoses: [1, 2], id: 34875, type: :SUBACK}},
-                   500
-
-    assert_receive {:sent, %Message.Subscribe{}}, 500
+    assert_receive {:received, %Message.SubAck{granted_qoses: [1, 2], id: 34875, type: :SUBACK}}
+    assert_receive {:sent, %Message.Subscribe{}}
 
     post_disconnect(pid)
   end
@@ -142,8 +126,8 @@ defmodule Hulaaki.ConnectionTCPTest do
 
     Connection.unsubscribe(pid, message)
 
-    assert_receive {:received, %Message.UnsubAck{id: 19234, type: :UNSUBACK}}, 500
-    assert_receive {:sent, %Message.Unsubscribe{}}, 500
+    assert_receive {:received, %Message.UnsubAck{id: 19234, type: :UNSUBACK}}
+    assert_receive {:sent, %Message.Unsubscribe{}}
 
     post_disconnect(pid)
   end
@@ -153,14 +137,14 @@ defmodule Hulaaki.ConnectionTCPTest do
 
     Connection.ping(pid)
 
-    assert_receive {:received, %Message.PingResp{type: :PINGRESP}}, 500
-    assert_receive {:sent, %Message.PingReq{}}, 500
+    assert_receive {:received, %Message.PingResp{type: :PINGRESP}}
+    assert_receive {:sent, %Message.PingReq{}}
 
     post_disconnect(pid)
   end
 
   test "receive messages published to a topic on qos 0 it has subscribed to" do
-    {:ok, pid1} = Connection.start_link(self())
+    {:ok, pid1} = Connection.start(self())
     pre_connect(pid1)
 
     id = :rand.uniform(65_535)
@@ -171,7 +155,7 @@ defmodule Hulaaki.ConnectionTCPTest do
     Connection.subscribe(pid1, message)
 
     spawn(fn ->
-      {:ok, pid2} = Connection.start_link(self())
+      {:ok, pid2} = Connection.start(self())
       pre_connect(pid2)
 
       topic = "qos0"
@@ -193,14 +177,13 @@ defmodule Hulaaki.ConnectionTCPTest do
                       message: "you better get this message on qos 0",
                       topic: "qos0",
                       type: :PUBLISH
-                    }},
-                   500
+                    }}
 
     post_disconnect(pid1)
   end
 
   test "receive messages published to a topic it has subscribed to on qos 1" do
-    {:ok, pid1} = Connection.start_link(self())
+    {:ok, pid1} = Connection.start(self())
     pre_connect(pid1)
 
     id = :rand.uniform(65_535)
@@ -211,7 +194,7 @@ defmodule Hulaaki.ConnectionTCPTest do
     Connection.subscribe(pid1, message)
 
     spawn(fn ->
-      {:ok, pid2} = Connection.start_link(self())
+      {:ok, pid2} = Connection.start(self())
       pre_connect(pid2)
 
       id = :rand.uniform(65_535)
@@ -235,14 +218,13 @@ defmodule Hulaaki.ConnectionTCPTest do
                       message: "you better get this message on qos 1",
                       topic: "random-topic-8234",
                       type: :PUBLISH
-                    }},
-                   500
+                    }}
 
     post_disconnect(pid1)
   end
 
   test "send publish ack after receiving publish messages published to a topic it has subscribed to on qos 1" do
-    {:ok, pid1} = Connection.start_link(self())
+    {:ok, pid1} = Connection.start(self())
     pre_connect(pid1)
 
     id = :rand.uniform(65_535)
@@ -253,7 +235,7 @@ defmodule Hulaaki.ConnectionTCPTest do
     Connection.subscribe(pid1, message)
 
     spawn(fn ->
-      {:ok, pid2} = Connection.start_link(self())
+      {:ok, pid2} = Connection.start(self())
       pre_connect(pid2)
 
       id = :rand.uniform(65_535)
@@ -277,13 +259,12 @@ defmodule Hulaaki.ConnectionTCPTest do
                       message: "you better get this message on qos 1",
                       topic: "random-topic-2850",
                       type: :PUBLISH
-                    }},
-                   500
+                    }}
 
     message = Message.publish_ack(id)
     Connection.publish_ack(pid1, message)
 
-    assert_receive {:sent, %Message.PubAck{}}, 500
+    assert_receive {:sent, %Message.PubAck{}}
 
     post_disconnect(pid1)
   end

--- a/test/hulaaki/connection_tcp_test.exs
+++ b/test/hulaaki/connection_tcp_test.exs
@@ -24,14 +24,15 @@ defmodule Hulaaki.ConnectionTCPTest do
   defp pre_connect(pid) do
     message = Message.connect(client_name(), "", "", "", "", 0, 0, 0, 100)
 
-    Connection.connect(
-      pid,
-      message,
-      host: TestConfig.mqtt_host(),
-      port: TestConfig.mqtt_port(),
-      timeout: TestConfig.mqtt_timeout(),
-      ssl: false
-    )
+    :ok =
+      Connection.connect(
+        pid,
+        message,
+        host: TestConfig.mqtt_host(),
+        port: TestConfig.mqtt_port(),
+        timeout: TestConfig.mqtt_timeout(),
+        ssl: false
+      )
   end
 
   defp post_disconnect(pid) do

--- a/test/hulaaki/connection_test.exs
+++ b/test/hulaaki/connection_test.exs
@@ -1,0 +1,126 @@
+defmodule Hulaaki.ConnectionTest do
+  use ExUnit.Case, async: true
+  alias Hulaaki.Connection
+  alias Hulaaki.Message
+
+  defmodule SampleTransport do
+    @behaviour Hulaaki.Transport
+    def connect(_host, _port, _opts, _timeout), do: {:ok, :socket}
+
+    def send(_socket, _packet), do: {:error, :send}
+
+    def close(_socket), do: :ok
+
+    def set_active_once(_socket), do: :ok
+
+    def packet_message, do: :sample
+    def closing_message, do: :sample_closed
+  end
+
+  setup do
+    {:ok, pid} = Connection.start(self())
+    {:ok, connection_pid: pid}
+  end
+
+  defp pre_connect(pid) do
+    message = Message.connect(TestHelper.random_name(), "", "", "", "", 0, 0, 0, 100)
+
+    {:error, :send} =
+      Connection.connect(
+        pid,
+        message,
+        host: TestConfig.mqtt_host(),
+        port: TestConfig.mqtt_port(),
+        timeout: TestConfig.mqtt_timeout(),
+        transport: SampleTransport
+      )
+  end
+
+  defp post_disconnect(pid) do
+    Connection.disconnect(pid)
+    Connection.stop(pid)
+  end
+
+  test "any call in non-connected connection returns error", %{connection_pid: pid} do
+    message = Message.publish(1, "", "", 0, 1, 0)
+
+    reply =
+      Connection.publish(
+        pid,
+        message
+      )
+
+    assert {:error, :not_connected} == reply
+    post_disconnect(pid)
+  end
+
+  test "publish in disconnected connection returns error", %{connection_pid: pid} do
+    pre_connect(pid)
+    message = Message.publish(1, "", "", 0, 1, 0)
+
+    reply =
+      Connection.publish(
+        pid,
+        message
+      )
+
+    assert {:error, :send} == reply
+    post_disconnect(pid)
+  end
+
+  test "subscribe in disconnected connection returns error", %{connection_pid: pid} do
+    pre_connect(pid)
+    message = Message.subscribe(1, [""], [0])
+
+    reply =
+      Connection.subscribe(
+        pid,
+        message
+      )
+
+    assert {:error, :send} == reply
+    post_disconnect(pid)
+  end
+
+  test "unsubscribe in disconnected connection returns error", %{connection_pid: pid} do
+    pre_connect(pid)
+    message = Message.unsubscribe(1, [""])
+
+    reply =
+      Connection.unsubscribe(
+        pid,
+        message
+      )
+
+    assert {:error, :send} == reply
+    post_disconnect(pid)
+  end
+
+  test "ping in disconnected connection returns error", %{connection_pid: pid} do
+    pre_connect(pid)
+    message = Message.ping_request()
+
+    reply =
+      Connection.ping(
+        pid,
+        message
+      )
+
+    assert {:error, :send} == reply
+    post_disconnect(pid)
+  end
+
+  test "disconnect in disconnected connection returns error", %{connection_pid: pid} do
+    pre_connect(pid)
+    message = Message.disconnect()
+
+    reply =
+      Connection.disconnect(
+        pid,
+        message
+      )
+
+    assert {:error, :send} == reply
+    post_disconnect(pid)
+  end
+end

--- a/test/hulaaki/connection_websocket_test.exs
+++ b/test/hulaaki/connection_websocket_test.exs
@@ -1,0 +1,292 @@
+defmodule Hulaaki.ConnectionWebsocketTest do
+  use ExUnit.Case
+  alias Hulaaki.Connection
+  alias Hulaaki.Message
+
+  # How to test disconnect message
+
+  defp client_name do
+    adjectives = ["lazy", "funny", "bright", "boring", "crazy", "lonely"]
+    nouns = ["thermometer", "switch", "scale", "bulb", "heater", "microwave"]
+
+    id = to_string(:rand.uniform(100_000))
+    [adjective] = adjectives |> Enum.shuffle() |> Enum.take(1)
+    [noun] = nouns |> Enum.shuffle() |> Enum.take(1)
+
+    adjective <> "-" <> noun <> "-" <> id
+  end
+
+  setup do
+    {:ok, pid} = Connection.start_link(self())
+    {:ok, connection_pid: pid}
+  end
+
+  defp pre_connect(pid) do
+    message = Message.connect(client_name(), "", "", "", "", 0, 0, 0, 100)
+
+    :ok =
+      Connection.connect(
+        pid,
+        message,
+        host: TestConfig.mqtt_host(),
+        port: TestConfig.mqtt_websocket_port(),
+        timeout: TestConfig.mqtt_timeout(),
+        transport: Hulaaki.Transport.WebSocket,
+        transport_opts: []
+      )
+  end
+
+  defp post_disconnect(pid) do
+    Connection.disconnect(pid)
+    Connection.stop(pid)
+  end
+
+  test "failed websocket connection returns an error tuple", %{connection_pid: pid} do
+    message = Message.connect(client_name(), "", "", "", "", 0, 0, 0, 100)
+
+    reply =
+      Connection.connect(
+        pid,
+        message,
+        host: TestConfig.mqtt_host(),
+        port: 7878,
+        timeout: 500,
+        transport: Hulaaki.Transport.WebSocket,
+        transport_opts: []
+      )
+
+    assert {:error, :timeout} == reply
+  end
+
+  test "connect receives ConnAck", %{connection_pid: pid} do
+    pre_connect(pid)
+
+    assert_receive {:received,
+                    %Message.ConnAck{return_code: 0, session_present: 0, type: :CONNACK}},
+                   500
+
+    assert_receive {:sent, %Message.Connect{}}, 500
+
+    post_disconnect(pid)
+  end
+
+  test "publish w. qos 1 receives PubAck", %{connection_pid: pid} do
+    pre_connect(pid)
+
+    id = 1122
+    topic = "a/b"
+    message = "a short message"
+    dup = 0
+    qos = 1
+    retain = 1
+    message = Message.publish(id, topic, message, dup, qos, retain)
+
+    Connection.publish(pid, message)
+
+    assert_receive {:received, %Message.PubAck{id: 1122, type: :PUBACK}}, 500
+    assert_receive {:sent, %Message.Publish{}}, 500
+
+    post_disconnect(pid)
+  end
+
+  test "publish w. qos 2 receives PubRec, publish_release receives PubComp", %{
+    connection_pid: pid
+  } do
+    pre_connect(pid)
+
+    id = 2345
+    topic = "a/b"
+    message = "a short message"
+    dup = 0
+    qos = 2
+    retain = 1
+    publish_message = Message.publish(id, topic, message, dup, qos, retain)
+
+    Connection.publish(pid, publish_message)
+
+    assert_receive {:received, %Message.PubRec{id: 2345, type: :PUBREC}}, 500
+    assert_receive {:sent, %Message.Publish{}}, 500
+
+    publish_release_message = Message.publish_release(id)
+
+    Connection.publish_release(pid, publish_release_message)
+
+    assert_receive {:received, %Message.PubComp{id: 2345, type: :PUBCOMP}}, 500
+    assert_receive {:sent, %Message.PubRel{}}, 500
+
+    post_disconnect(pid)
+  end
+
+  test "subscribe receives SubAck", %{connection_pid: pid} do
+    pre_connect(pid)
+
+    id = 34875
+    topics = ["hello", "cool"]
+    qoses = [1, 2]
+    message = Message.subscribe(id, topics, qoses)
+
+    Connection.subscribe(pid, message)
+
+    assert_receive {:received, %Message.SubAck{granted_qoses: [1, 2], id: 34875, type: :SUBACK}},
+                   500
+
+    assert_receive {:sent, %Message.Subscribe{}}, 500
+
+    post_disconnect(pid)
+  end
+
+  test "unsubscribe receives UnsubAck", %{connection_pid: pid} do
+    pre_connect(pid)
+
+    id = 19_234
+    topics = ["what"]
+    message = Message.unsubscribe(id, topics)
+
+    Connection.unsubscribe(pid, message)
+
+    assert_receive {:received, %Message.UnsubAck{id: 19234, type: :UNSUBACK}}, 500
+    assert_receive {:sent, %Message.Unsubscribe{}}, 500
+
+    post_disconnect(pid)
+  end
+
+  test "ping receives PingResp", %{connection_pid: pid} do
+    pre_connect(pid)
+
+    Connection.ping(pid)
+
+    assert_receive {:received, %Message.PingResp{type: :PINGRESP}}, 500
+    assert_receive {:sent, %Message.PingReq{}}, 500
+
+    post_disconnect(pid)
+  end
+
+  test "receive messages published to a topic on qos 0 it has subscribed to" do
+    {:ok, pid1} = Connection.start_link(self())
+    pre_connect(pid1)
+
+    id = :rand.uniform(65_535)
+    topics = ["qos0"]
+    qoses = [0]
+    message = Message.subscribe(id, topics, qoses)
+
+    Connection.subscribe(pid1, message)
+
+    spawn(fn ->
+      {:ok, pid2} = Connection.start_link(self())
+      pre_connect(pid2)
+
+      topic = "qos0"
+      message = "you better get this message on qos 0"
+      dup = 0
+      qos = 0
+      retain = 0
+      message0 = Message.publish(topic, message, dup, qos, retain)
+      Connection.publish(pid2, message0)
+
+      post_disconnect(pid2)
+    end)
+
+    assert_receive {:received,
+                    %Message.Publish{
+                      dup: 0,
+                      qos: 0,
+                      retain: 0,
+                      message: "you better get this message on qos 0",
+                      topic: "qos0",
+                      type: :PUBLISH
+                    }},
+                   500
+
+    post_disconnect(pid1)
+  end
+
+  test "receive messages published to a topic it has subscribed to on qos 1" do
+    {:ok, pid1} = Connection.start_link(self())
+    pre_connect(pid1)
+
+    id = :rand.uniform(65_535)
+    topics = ["random-topic-8234"]
+    qoses = [1]
+    message = Message.subscribe(id, topics, qoses)
+
+    Connection.subscribe(pid1, message)
+
+    spawn(fn ->
+      {:ok, pid2} = Connection.start_link(self())
+      pre_connect(pid2)
+
+      id = :rand.uniform(65_535)
+      topic = "random-topic-8234"
+      message = "you better get this message on qos 1"
+      dup = 0
+      qos = 1
+      retain = 0
+      message1 = Message.publish(id, topic, message, dup, qos, retain)
+      Connection.publish(pid2, message1)
+
+      post_disconnect(pid2)
+    end)
+
+    assert_receive {:received,
+                    %Message.Publish{
+                      id: 1,
+                      dup: 0,
+                      qos: 1,
+                      retain: 0,
+                      message: "you better get this message on qos 1",
+                      topic: "random-topic-8234",
+                      type: :PUBLISH
+                    }},
+                   500
+
+    post_disconnect(pid1)
+  end
+
+  test "send publish ack after receiving publish messages published to a topic it has subscribed to on qos 1" do
+    {:ok, pid1} = Connection.start_link(self())
+    pre_connect(pid1)
+
+    id = :rand.uniform(65_535)
+    topics = ["random-topic-2850"]
+    qoses = [1]
+    message = Message.subscribe(id, topics, qoses)
+
+    Connection.subscribe(pid1, message)
+
+    spawn(fn ->
+      {:ok, pid2} = Connection.start_link(self())
+      pre_connect(pid2)
+
+      id = :rand.uniform(65_535)
+      topic = "random-topic-2850"
+      message = "you better get this message on qos 1"
+      dup = 0
+      qos = 1
+      retain = 0
+      message1 = Message.publish(id, topic, message, dup, qos, retain)
+      Connection.publish(pid2, message1)
+
+      post_disconnect(pid2)
+    end)
+
+    assert_receive {:received,
+                    %Message.Publish{
+                      id: 1,
+                      dup: 0,
+                      qos: 1,
+                      retain: 0,
+                      message: "you better get this message on qos 1",
+                      topic: "random-topic-2850",
+                      type: :PUBLISH
+                    }},
+                   500
+
+    message = Message.publish_ack(id)
+    Connection.publish_ack(pid1, message)
+
+    assert_receive {:sent, %Message.PubAck{}}, 500
+
+    post_disconnect(pid1)
+  end
+end

--- a/test/hulaaki/decoder_test.exs
+++ b/test/hulaaki/decoder_test.exs
@@ -1,5 +1,5 @@
 defmodule Hulaaki.DecoderTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Hulaaki.Decoder
   alias Hulaaki.Message
   alias Hulaaki.Packet

--- a/test/hulaaki/encoder_test.exs
+++ b/test/hulaaki/encoder_test.exs
@@ -1,5 +1,5 @@
 defmodule Hulaaki.EncoderTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Hulaaki.Encoder
   alias Hulaaki.Message
 

--- a/test/hulaaki/message_test.exs
+++ b/test/hulaaki/message_test.exs
@@ -1,5 +1,5 @@
 defmodule Hulaaki.MessageTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Hulaaki.Message
 
   test "connect build a Connect message struct" do

--- a/test/hulaaki_test.exs
+++ b/test/hulaaki_test.exs
@@ -1,5 +1,5 @@
 defmodule HulaakiTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Hulaaki.Message
   alias Hulaaki.Packet
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,17 @@
 ExUnit.start()
 
 defmodule TestConfig do
+
+  def ssl_options do
+    case :erlang.system_info(:otp_release) do
+      '21' -> [
+        ciphers: [
+          %{cipher: :"3des_ede_cbc", key_exchange: :rsa, mac: :sha, prf: :default_prf}
+        ]
+      ]
+      _ -> []
+    end
+  end
   def mqtt_host do
     System.get_env("MQTT_HOST") || "localhost"
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -26,6 +26,11 @@ defmodule TestConfig do
     port
   end
 
+  def mqtt_websocket_port do
+    {port, _} = (System.get_env("MQTT_WEBSOCKET_PORT") || "1884") |> Integer.parse()
+    port
+  end
+
   def mqtt_timeout do
     2000
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,14 @@
+ExUnit.configure(assert_receive_timeout: 1_000)
 ExUnit.start()
+
+defmodule TestHelper do
+  def random_name do
+    adjectives = ["lazy", "funny", "bright", "boring", "crazy", "lonely"]
+    nouns = ["thermometer", "switch", "scale", "bulb", "heater", "microwave"]
+
+    "#{Enum.random(adjectives)}-#{Enum.random(nouns)}-#{:rand.uniform(100_000)}"
+  end
+end
 
 defmodule TestConfig do
 


### PR DESCRIPTION
For an internal project at Talkdesk we had the need to connect to a MQTT server via websockets in one of our Elixir projects.

This PR includes several features, but we tried to tidy up the commits so that you can eventually accept some that may make sense for Hulaaki, while still being able to refuse others.

- We added a `Hulaaki.Transport` behavior that is used as a contract to implement transport layers other than ssl and tcp.
- We've made some improvements around tests such as explicitly fail upon `Connection.connect` during setup, made the tests async to improve performance
- We created a new transport layers based on the `Hulaaki.Transport` behavior to support websockets. We made tried both [Socket](https://github.com/meh/elixir-socket) and [Gun](https://github.com/ninenines/gun) but opted to suggest Socket due to stability/compatibility concerns.
 - We promoted the library to Application to allow us to have a supervision tree that takes care of connection processes and deal with failures (by providing a new `on_connection_down` callback.
- While working on the project we tested and updated it to support Elixir >= 1.6 and OTP up to 21.
